### PR TITLE
Fill Project Information From Template

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,21 @@
-This is free and unencumbered software released into the public domain.
+MIT License
 
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
+Copyright (c) 2024 Alfi Maulana
 
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-For more information, please refer to <http://unlicense.org/>
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,9 @@
-<!-- Clear the content of this file and replace it with the description of your project. -->
-<!-- Learn more: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes -->
+# Cache Action
 
-# Action Starter
+Save and restore cache in [GitHub Actions](https://github.com/features/actions).
 
-A minimalistic [GitHub repository template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) to kickstart your [GitHub Action](https://github.com/features/actions) project.
+## License
 
-## Key Features
+This project is licensed under the terms of the [MIT License](./LICENSE).
 
-- Includes a sample metadata file for a GitHub action.
-- Develops logic for the GitHub action in [Node.js](https://nodejs.org/en) using the following stacks:
-  - [Yarn](https://yarnpkg.com/) for project management.
-  - [TypeScript](https://www.typescriptlang.org/) for type checking.
-  - [Jest](https://jestjs.io/) for unit testing.
-  - [ESLint](https://eslint.org/) for static analysis.
-  - [Prettier](https://prettier.io/) for code formatting.
-- Provides a sample workflow file for testing the action.
-- Supports dependency updates with [Dependabot](https://docs.github.com/en/code-security/dependabot).
-
-## Usage
-
-> For detailed instructions on how to use this template, please refer to [the wiki](https://github.com/threeal/action-starter/wiki).
-
-- Create a new repository from this template.
-- Make the following changes to the new repository:
-  - Replace the [LICENSE](LICENSE) file.
-  - Update the content of the [README](README.md) file.
-  - Define the action information in the [action.yml](action.yml) file.
-  - Develop the action logic in the [src/index.ts](src/index.ts) file. Use these commands for development:
-    - `yarn install`: Initialize project dependencies.
-    - `yarn format`: Format the source code.
-    - `yarn lint`: Lint the source code.
-    - `yarn test`: Run unit tests. Write the unit tests in files with `*.test.ts` pattern.
-    - `yarn build`: Build the source code into a single file for distribution.
-  - Write tests for the action in the [test workflow](.github/workflows/test.yaml) file.
-- Finalize the action and cut the first release.
+Copyright © 2024 [Alfi Maulana](https://github.com/threeal)

--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,8 @@
-# Modify the following action metadata according to the specification of your JavaScript action.
-# Learn more: https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions
-
-name: Mkdir Action
+name: Cache Action
 author: Alfi Maulana
-description: Create a new directory
+description: Save and restore cache
 branding:
-  icon: folder-plus
+  icon: archive
   color: black
 inputs:
   path:


### PR DESCRIPTION
This pull request resolves #4 by filling in the following items from the template:

- Update the license file declaration to use the [MIT License](https://opensource.org/license/mit/).
- Fill the `README.md` file.
- Fill the action metadata in the `action.yml` file.