### PR TITLE
Modify Action to Compress Files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,9 +42,13 @@ jobs:
             dist
           sparse-checkout-cone-mode: false
 
-      - name: Prepare File
+      - name: Prepare Files
         shell: bash
-        run: echo "some value" >> file.txt
+        run: |
+          echo "a content" >> a-file
+          echo "another content" >> another-file
+          mkdir a-dir
+          echo "a content" >> a-dir/a-file
 
       - name: Save Cache
         id: save-cache
@@ -52,7 +56,9 @@ jobs:
         with:
           key: some-key-${{ matrix.os }}
           version: ${{ github.run_id }}
-          file: file.txt
+          files: |
+            a-file another-file
+            a-dir/a-file
 
       - name: Check Output
         shell: bash
@@ -82,12 +88,17 @@ jobs:
         with:
           key: some-key-${{ matrix.os }}
           version: ${{ github.run_id }}
-          file: file.txt
+          files: |
+            a-file another-file
+            a-dir/a-file
 
       - name: Check Output
         shell: bash
         run: test "${{ steps.restore-cache.outputs.restored }}" == "true"
 
-      - name: Check File
+      - name: Check Files
         shell: bash
-        run: test "$(cat file.txt)" == "some value"
+        run: |
+          test "$(cat a-file)" == "a content"
+          test "$(cat another-file)" == "another content"
+          test "$(cat a-dir/a-file)" == "a content"

--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,8 @@ inputs:
   version:
     description: The cache version
     required: true
-  file:
-    description: The file to be cached
+  files:
+    description: The files to be cached
     required: true
 outputs:
   restored:

--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -156,7 +156,7 @@ async function extractFiles(archivePath) {
 }
 
 /**
- * Restores a file from the cache using the specified key and version.
+ * Restores files from the cache using the specified key and version.
  *
  * @param key - The cache key.
  * @param version - The cache version.

--- a/dist/post.mjs
+++ b/dist/post.mjs
@@ -198,16 +198,16 @@ async function compressFiles(archivePath, filePaths) {
 }
 
 /**
- * Saves a file to the cache using the specified key and version.
+ * Saves files to the cache using the specified key and version.
  *
  * @param key - The cache key.
  * @param version - The cache version.
- * @param filePath - The path of the file to be saved.
+ * @param filePath - The paths of the files to be saved.
  * @returns A promise that resolves to a boolean value indicating whether the
  * file was saved successfully.
  */
-async function saveCache(key, version, filePath) {
-    await compressFiles("cache.tar", [filePath]);
+async function saveCache(key, version, filePaths) {
+    await compressFiles("cache.tar", filePaths);
     const fileSize = fs.statSync("cache.tar").size;
     const cacheId = await reserveCache(key, version, fileSize);
     if (cacheId === null)
@@ -226,9 +226,11 @@ async function saveCache(key, version, filePath) {
 try {
     const key = getInput("key");
     const version = getInput("version");
-    const filePath = getInput("file");
+    const filePaths = getInput("files")
+        .split(/\s+/)
+        .filter((arg) => arg != "");
     logInfo("Saving cache...");
-    if (await saveCache(key, version, filePath)) {
+    if (await saveCache(key, version, filePaths)) {
         logInfo("Cache successfully saved");
     }
     else {

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -79,7 +79,7 @@ describe("save files to caches", () => {
 
     compressFiles.mockImplementation(async (archivePath, filePaths) => {
       expect(archivePath).toBe("cache.tar");
-      expect(filePaths).toEqual(["some file path"]);
+      expect(filePaths).toEqual(["some file path", "some other file path"]);
     });
 
     fs.statSync.mockImplementation((path) => {
@@ -122,7 +122,10 @@ describe("save files to caches", () => {
       expect(size).toBe(1024);
     });
 
-    const saved = await saveCache("some key", "some version", "some file path");
+    const saved = await saveCache("some key", "some version", [
+      "some file path",
+      "some other file path",
+    ]);
     expect(saved).toBe(true);
   });
 
@@ -131,7 +134,7 @@ describe("save files to caches", () => {
 
     compressFiles.mockImplementation(async (archivePath, filePaths) => {
       expect(archivePath).toBe("cache.tar");
-      expect(filePaths).toEqual(["some file path"]);
+      expect(filePaths).toEqual(["some file path", "some other file path"]);
     });
 
     fs.statSync.mockImplementation((path) => {
@@ -146,7 +149,10 @@ describe("save files to caches", () => {
       return null;
     });
 
-    const saved = await saveCache("some key", "some version", "some file path");
+    const saved = await saveCache("some key", "some version", [
+      "some file path",
+      "some other file path",
+    ]);
     expect(saved).toBe(false);
   });
 });

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -11,7 +11,7 @@ import { downloadFile } from "./api/download.js";
 import { compressFiles, extractFiles } from "./archive.js";
 
 /**
- * Restores a file from the cache using the specified key and version.
+ * Restores files from the cache using the specified key and version.
  *
  * @param key - The cache key.
  * @param version - The cache version.
@@ -30,20 +30,20 @@ export async function restoreCache(
 }
 
 /**
- * Saves a file to the cache using the specified key and version.
+ * Saves files to the cache using the specified key and version.
  *
  * @param key - The cache key.
  * @param version - The cache version.
- * @param filePath - The path of the file to be saved.
+ * @param filePath - The paths of the files to be saved.
  * @returns A promise that resolves to a boolean value indicating whether the
  * file was saved successfully.
  */
 export async function saveCache(
   key: string,
   version: string,
-  filePath: string,
+  filePaths: string[],
 ): Promise<boolean> {
-  await compressFiles("cache.tar", [filePath]);
+  await compressFiles("cache.tar", filePaths);
   const fileSize = fs.statSync("cache.tar").size;
   const cacheId = await reserveCache(key, version, fileSize);
   if (cacheId === null) return false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,10 +4,9 @@ import { restoreCache } from "./cache.js";
 try {
   const key = getInput("key");
   const version = getInput("version");
-  const filePath = getInput("file");
 
   logInfo("Restoring cache...");
-  if (await restoreCache(key, version, filePath)) {
+  if (await restoreCache(key, version)) {
     logInfo("Cache successfully restored");
     setOutput("restored", "true");
   } else {

--- a/src/post.ts
+++ b/src/post.ts
@@ -4,10 +4,12 @@ import { saveCache } from "./cache.js";
 try {
   const key = getInput("key");
   const version = getInput("version");
-  const filePath = getInput("file");
+  const filePaths = getInput("files")
+    .split(/\s+/)
+    .filter((arg) => arg != "");
 
   logInfo("Saving cache...");
-  if (await saveCache(key, version, filePath)) {
+  if (await saveCache(key, version, filePaths)) {
     logInfo("Cache successfully saved");
   } else {
     logInfo("Cache already exists");


### PR DESCRIPTION
This pull request resolves #8 by updating the action to support caching multiple files. This is achieved by compressing the specified files into a single archive and then saving the archive to the cache.