### PR TITLE
Modify Action to Save Cache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,9 +42,13 @@ jobs:
             dist
           sparse-checkout-cone-mode: false
 
+      - name: Prepare File
+        shell: bash
+        run: echo "some value" >> file.txt
+
       - name: Reserve Cache
         uses: ./cache-action
         with:
           key: some-key-${{ matrix.os }}
           version: ${{ github.run_id }}
-          size: 1024
+          file: file.txt

--- a/action.yml
+++ b/action.yml
@@ -6,13 +6,13 @@ branding:
   color: black
 inputs:
   key:
-    description: The key of the cache to reserve
+    description: The key of the cache
     required: true
   version:
-    description: The version of the cache to reserve
+    description: The version of the cache
     required: true
-  size:
-    description: The size of the cache to reserve, in bytes
+  file:
+    description: The file to cache
     required: true
 runs:
   using: node20

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -97,7 +97,7 @@ async function handleErrorResponse(res) {
 }
 
 /**
- * Reserve a cache with the specified key, version, and size.
+ * Reserves a cache with the specified key, version, and size.
  *
  * @param key - The key of the cache to reserve.
  * @param version - The version of the cache to reserve.

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -147,6 +147,21 @@ async function uploadCache(id, file, fileSize) {
     }
     handleResponse(res);
 }
+/**
+ * Commits a cache with the specified ID.
+ *
+ * @param id - The cache ID.
+ * @param size - The size of the cache in bytes.
+ * @returns A promise that resolves with nothing.
+ */
+async function commitCache(id, size) {
+    const req = createRequest(`caches/${id}`, { method: "POST" });
+    const res = await sendJsonRequest(req, { size });
+    if (res.statusCode !== 204) {
+        throw await handleErrorResponse(res);
+    }
+    handleResponse(res);
+}
 
 try {
     const filePath = getInput("file");
@@ -163,6 +178,9 @@ try {
     });
     await uploadCache(cacheId, file, fileSize);
     logInfo("Cache uploaded");
+    logInfo("Commiting cache...");
+    await commitCache(cacheId, fileSize);
+    logInfo("Cache committed");
 }
 catch (err) {
     logError(err);

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -3,13 +3,17 @@ import { jest } from "@jest/globals";
 const createRequest = jest.fn();
 const handleErrorResponse = jest.fn();
 const handleJsonResponse = jest.fn();
+const handleResponse = jest.fn();
 const sendJsonRequest = jest.fn();
+const sendStreamRequest = jest.fn();
 
 jest.unstable_mockModule("./api.js", () => ({
   createRequest,
   handleErrorResponse,
   handleJsonResponse,
+  handleResponse,
   sendJsonRequest,
+  sendStreamRequest,
 }));
 
 describe("reserve caches", () => {

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -117,3 +117,47 @@ describe("upload files to caches", () => {
     await expect(prom).rejects.toThrow("some error");
   });
 });
+
+describe("commit caches", () => {
+  beforeAll(() => {
+    createRequest.mockImplementation((resourcePath, options) => {
+      expect(resourcePath).toBe("caches/32");
+      expect(options).toEqual({ method: "POST" });
+      return "some request";
+    });
+  });
+
+  it("should commit a cache", async () => {
+    const { commitCache } = await import("./cache.js");
+
+    sendJsonRequest.mockImplementation(async (req, data) => {
+      expect(req).toBe("some request");
+      expect(data).toEqual({ size: 1024 });
+      return { statusCode: 204 };
+    });
+
+    handleResponse.mockImplementation(async (res) => {
+      expect(res).toEqual({ statusCode: 204 });
+    });
+
+    await commitCache(32, 1024);
+  });
+
+  it("should fail to commit a cache", async () => {
+    const { commitCache } = await import("./cache.js");
+
+    sendJsonRequest.mockImplementation(async (req, data) => {
+      expect(req).toBe("some request");
+      expect(data).toEqual({ size: 1024 });
+      return { statusCode: 500 };
+    });
+
+    handleErrorResponse.mockImplementation(async (res) => {
+      expect(res).toEqual({ statusCode: 500 });
+      return new Error("some error");
+    });
+
+    const prom = commitCache(32, 1024);
+    await expect(prom).rejects.toThrow("some error");
+  });
+});

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,12 +1,16 @@
+import stream from "node:stream";
+
 import {
   createRequest,
-  handleJsonResponse,
   handleErrorResponse,
+  handleJsonResponse,
+  handleResponse,
   sendJsonRequest,
+  sendStreamRequest,
 } from "./api.js";
 
 /**
- * Reserve a cache with the specified key, version, and size.
+ * Reserves a cache with the specified key, version, and size.
  *
  * @param key - The key of the cache to reserve.
  * @param version - The version of the cache to reserve.
@@ -25,4 +29,25 @@ export async function reserveCache(
   }
   const { cacheId } = await handleJsonResponse<{ cacheId: number }>(res);
   return cacheId;
+}
+
+/**
+ * Uploads a file to a cache with the specified ID.
+ *
+ * @param id - The cache ID.
+ * @param file - The readable stream of the file to upload.
+ * @param fileSize - The size of the file to upload, in bytes.
+ * @returns A promise that resolves with nothing.
+ */
+export async function uploadCache(
+  id: number,
+  file: stream.Readable,
+  fileSize: number,
+): Promise<void> {
+  const req = createRequest(`caches/${id}`, { method: "PATCH" });
+  const res = await sendStreamRequest(req, file, 0, fileSize);
+  if (res.statusCode !== 204) {
+    throw await handleErrorResponse(res);
+  }
+  handleResponse(res);
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -51,3 +51,19 @@ export async function uploadCache(
   }
   handleResponse(res);
 }
+
+/**
+ * Commits a cache with the specified ID.
+ *
+ * @param id - The cache ID.
+ * @param size - The size of the cache in bytes.
+ * @returns A promise that resolves with nothing.
+ */
+export async function commitCache(id: number, size: number): Promise<void> {
+  const req = createRequest(`caches/${id}`, { method: "POST" });
+  const res = await sendJsonRequest(req, { size });
+  if (res.statusCode !== 204) {
+    throw await handleErrorResponse(res);
+  }
+  handleResponse(res);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,28 @@
 import { getInput, logError, logInfo } from "gha-utils";
-import { reserveCache } from "./cache.js";
+import fs from "node:fs";
+import { reserveCache, uploadCache } from "./cache.js";
 
 try {
+  const filePath = getInput("file");
+  const fileSize = fs.statSync(filePath).size;
+
   logInfo("Reserving cache...");
   const cacheId = await reserveCache(
     getInput("key"),
     getInput("version"),
-    parseInt(getInput("size"), 10),
+    fileSize,
   );
-  logInfo(`Reserved cache with id: ${cacheId}`);
+  logInfo(`Cache reserved with id: ${cacheId}`);
+
+  logInfo("Uploading cache...");
+  const file = fs.createReadStream(filePath, {
+    fd: fs.openSync(filePath, "r"),
+    autoClose: false,
+    start: 0,
+    end: fileSize,
+  });
+  await uploadCache(cacheId, file, fileSize);
+  logInfo("Cache uploaded");
 } catch (err) {
   logError(err);
   process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { getInput, logError, logInfo } from "gha-utils";
 import fs from "node:fs";
-import { reserveCache, uploadCache } from "./cache.js";
+import { commitCache, reserveCache, uploadCache } from "./cache.js";
 
 try {
   const filePath = getInput("file");
@@ -23,6 +23,10 @@ try {
   });
   await uploadCache(cacheId, file, fileSize);
   logInfo("Cache uploaded");
+
+  logInfo("Commiting cache...");
+  await commitCache(cacheId, fileSize);
+  logInfo("Cache committed");
 } catch (err) {
   logError(err);
   process.exit(1);


### PR DESCRIPTION
This pull request resolves #15 by modifying the action to save cache by uploading a file and then committing the cache. This change also includes adding several new functions, such as `uploadCache` and `commitCache`, along with their corresponding tests.