### PR TITLE
Refactor Send Cache API Request Function

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -32,26 +32,36 @@ function logError(err) {
 }
 
 /**
- * Sends an HTTPS request containing JSON data to the GitHub cache API endpoint.
+ * Creates an HTTPS request for the GitHub cache API endpoint.
  *
  * @param resourcePath - The path of the resource to be accessed in the API.
  * @param options - The options for the HTTPS request (e.g., method, headers).
+ * @returns An HTTPS request object.
+ */
+function createRequest(resourcePath, options) {
+    const req = https.request(`${process.env["ACTIONS_CACHE_URL"]}_apis/artifactcache/${resourcePath}`, options);
+    req.setHeader("Accept", "application/json;api-version=6.0-preview");
+    req.setHeader("Authorization", `Bearer ${process.env["ACTIONS_RUNTIME_TOKEN"]}`);
+    return req;
+}
+/**
+ * Sends an HTTPS request containing JSON data.
+ *
+ * @param req - The HTTPS request object.
  * @param data - The JSON data to be sent in the request body.
  * @returns A promise that resolves to an HTTPS response object.
  */
-async function sendJsonRequest(resourcePath, options, data) {
+async function sendJsonRequest(req, data) {
     return new Promise((resolve, reject) => {
-        const req = https.request(`${process.env["ACTIONS_CACHE_URL"]}_apis/artifactcache/${resourcePath}`, options, (res) => resolve(res));
-        req.setHeader("Accept", "application/json;api-version=6.0-preview");
-        req.setHeader("Authorization", `Bearer ${process.env["ACTIONS_RUNTIME_TOKEN"]}`);
         req.setHeader("Content-Type", "application/json");
+        req.on("response", (res) => resolve(res));
         req.on("error", (err) => reject(err));
         req.write(JSON.stringify(data));
         req.end();
     });
 }
 /**
- * Handles an HTTPS response containing JSON data from the GitHub cache API endpoint.
+ * Handles an HTTPS response containing JSON data.
  *
  * @param res - The HTTPS response object.
  * @returns A promise that resolves to the parsed JSON data.
@@ -75,7 +85,8 @@ async function handleJsonResponse(res) {
  * @returns A promise that resolves with the reserved cache ID.
  */
 async function reserveCache(key, version, size) {
-    const res = await sendJsonRequest("caches", { method: "POST" }, { key, version, cacheSize: size });
+    const req = createRequest("caches", { method: "POST" });
+    const res = await sendJsonRequest(req, { key, version, cacheSize: size });
     if (res.statusCode !== 201) {
         throw new Error(`failed to reserve cache: ${res.statusCode}}`);
     }

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -32,15 +32,15 @@ function logError(err) {
 }
 
 /**
- * Sends an HTTPS request to the GitHub cache API endpoint.
+ * Sends an HTTPS request containing JSON data to the GitHub cache API endpoint.
  *
  * @param resourcePath - The path of the resource to be accessed in the API.
  * @param options - The options for the HTTPS request (e.g., method, headers).
- * @param data - The data to be sent in the request body (optional).
+ * @param data - The JSON data to be sent in the request body.
  * @returns A promise that resolves to a tuple containing the response status
  * code and the parsed response data.
  */
-async function sendCacheApiRequest(resourcePath, options, data) {
+async function sendJsonRequest(resourcePath, options, data) {
     return new Promise((resolve, reject) => {
         const req = https.request(`${process.env["ACTIONS_CACHE_URL"]}_apis/artifactcache/${resourcePath}`, options, (res) => {
             let data = "";
@@ -53,9 +53,7 @@ async function sendCacheApiRequest(resourcePath, options, data) {
         req.setHeader("Authorization", `Bearer ${process.env["ACTIONS_RUNTIME_TOKEN"]}`);
         req.setHeader("Content-Type", "application/json");
         req.on("error", (err) => reject(err));
-        if (data !== undefined) {
-            req.write(JSON.stringify(data));
-        }
+        req.write(JSON.stringify(data));
         req.end();
     });
 }
@@ -69,7 +67,7 @@ async function sendCacheApiRequest(resourcePath, options, data) {
  * @returns A promise that resolves with the reserved cache ID.
  */
 async function reserveCache(key, version, size) {
-    const [status, { cacheId }] = await sendCacheApiRequest("caches", { method: "POST" }, { key, version, cacheSize: size });
+    const [status, { cacheId }] = await sendJsonRequest("caches", { method: "POST" }, { key, version, cacheSize: size });
     if (status !== 201) {
         throw new Error(`failed to reserve cache: ${status}}`);
     }

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -37,24 +37,32 @@ function logError(err) {
  * @param resourcePath - The path of the resource to be accessed in the API.
  * @param options - The options for the HTTPS request (e.g., method, headers).
  * @param data - The JSON data to be sent in the request body.
- * @returns A promise that resolves to a tuple containing the response status
- * code and the parsed response data.
+ * @returns A promise that resolves to an HTTPS response object.
  */
 async function sendJsonRequest(resourcePath, options, data) {
     return new Promise((resolve, reject) => {
-        const req = https.request(`${process.env["ACTIONS_CACHE_URL"]}_apis/artifactcache/${resourcePath}`, options, (res) => {
-            let data = "";
-            res.on("data", (chunk) => (data += chunk.toString()));
-            res.on("end", () => {
-                resolve([res.statusCode, JSON.parse(data)]);
-            });
-        });
+        const req = https.request(`${process.env["ACTIONS_CACHE_URL"]}_apis/artifactcache/${resourcePath}`, options, (res) => resolve(res));
         req.setHeader("Accept", "application/json;api-version=6.0-preview");
         req.setHeader("Authorization", `Bearer ${process.env["ACTIONS_RUNTIME_TOKEN"]}`);
         req.setHeader("Content-Type", "application/json");
         req.on("error", (err) => reject(err));
         req.write(JSON.stringify(data));
         req.end();
+    });
+}
+/**
+ * Handles an HTTPS response containing JSON data from the GitHub cache API endpoint.
+ *
+ * @param res - The HTTPS response object.
+ * @returns A promise that resolves to the parsed JSON data.
+ */
+async function handleJsonResponse(res) {
+    return new Promise((resolve) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk.toString()));
+        res.on("end", () => {
+            resolve(JSON.parse(data));
+        });
     });
 }
 
@@ -67,10 +75,11 @@ async function sendJsonRequest(resourcePath, options, data) {
  * @returns A promise that resolves with the reserved cache ID.
  */
 async function reserveCache(key, version, size) {
-    const [status, { cacheId }] = await sendJsonRequest("caches", { method: "POST" }, { key, version, cacheSize: size });
-    if (status !== 201) {
-        throw new Error(`failed to reserve cache: ${status}}`);
+    const res = await sendJsonRequest("caches", { method: "POST" }, { key, version, cacheSize: size });
+    if (res.statusCode !== 201) {
+        throw new Error(`failed to reserve cache: ${res.statusCode}}`);
     }
+    const { cacheId } = (await handleJsonResponse(res));
     return cacheId;
 }
 

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -3,54 +3,65 @@ import http from "node:http";
 
 jest.unstable_mockModule("node:https", () => ({ default: http }));
 
+type ServerHandlers = (
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+) => boolean;
+const createServer = (handlers: ServerHandlers[]): http.Server => {
+  process.env["ACTIONS_CACHE_URL"] = "http://localhost:12345/";
+  process.env["ACTIONS_RUNTIME_TOKEN"] = "some token";
+
+  const server = http.createServer((req, res) => {
+    const token = req.headers.authorization;
+    if (token !== "Bearer some token") {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(`invalid bearer token: ${token}`));
+      return;
+    }
+
+    for (const handler of handlers) {
+      if (handler(req, res)) return;
+    }
+
+    res.writeHead(404);
+    res.end();
+  });
+
+  server.listen(12345);
+  return server;
+};
+
 describe("send requests containing JSON data to GitHub cache API endpoints", () => {
   it("should send a request to a valid endpoint", async () => {
     const { sendJsonRequest } = await import("./api.js");
 
-    process.env["ACTIONS_CACHE_URL"] = "http://localhost:12345/";
-    process.env["ACTIONS_RUNTIME_TOKEN"] = "some token";
-
-    const server = http.createServer((req, res) => {
-      let rawData = "";
-      req.on("data", (chunk) => (rawData += chunk.toString()));
-      req.on("end", () => {
-        const token = req.headers.authorization;
-        if (token !== "Bearer some token") {
-          res.writeHead(401, { "Content-Type": "application/json" });
-          res.end(JSON.stringify(`invalid bearer token: ${token}`));
-          return;
-        }
-
-        if (
-          req.method === "POST" &&
-          req.url === "/_apis/artifactcache/caches"
-        ) {
+    const server = createServer([
+      (req, res) => {
+        if (req.method !== "POST") return false;
+        if (req.url !== "/_apis/artifactcache/caches") return false;
+        let rawData = "";
+        req.on("data", (chunk) => (rawData += chunk.toString()));
+        req.on("end", () => {
           const data = JSON.parse(rawData);
           if (data.message == "some message") {
-            res.writeHead(200, { "Content-Type": "application/json" });
-            res.end(JSON.stringify({ message: "some other message" }));
+            res.writeHead(200);
+            res.end();
+            return;
           } else {
-            res.writeHead(400, { "Content-Type": "application/json" });
-            res.end(JSON.stringify(`invalid message: ${data.message}`));
+            res.writeHead(400);
+            res.end();
           }
-          return;
-        }
+        });
+        return true;
+      },
+    ]);
 
-        res.writeHead(404, { "Content-Type": "application/json" });
-        res.end(
-          JSON.stringify(`unknown resource: ${req.method} on ${req.url}`),
-        );
-      });
-    });
-    server.listen(12345);
-
-    const res = await sendJsonRequest<{ message: string }>(
+    const res = await sendJsonRequest(
       "caches",
       { method: "POST" },
       { message: "some message" },
     );
-
-    expect(res).toEqual([200, { message: "some other message" }]);
+    expect(res.statusCode).toEqual(200);
 
     server.close();
   });
@@ -63,5 +74,29 @@ describe("send requests containing JSON data to GitHub cache API endpoints", () 
     await expect(
       sendJsonRequest("caches", { method: "POST" }, {}),
     ).rejects.toThrow();
+  });
+});
+
+describe("handle responses containing JSON data from GitHub cache API endpoints", () => {
+  it("should handle a response from an endpoint", async () => {
+    const { handleJsonResponse, sendJsonRequest } = await import("./api.js");
+
+    const server = createServer([
+      (req, res) => {
+        if (req.method !== "GET") return false;
+        if (req.url !== "/_apis/artifactcache/caches") return false;
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ message: "some message" }));
+        return true;
+      },
+    ]);
+
+    const res = await sendJsonRequest("caches", { method: "GET" }, {});
+    expect(res.statusCode).toEqual(200);
+
+    const data = await handleJsonResponse(res);
+    expect(data).toEqual({ message: "some message" });
+
+    server.close();
   });
 });

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -3,9 +3,9 @@ import http from "node:http";
 
 jest.unstable_mockModule("node:https", () => ({ default: http }));
 
-describe("send HTTPS requests to GitHub cache API endpoints", () => {
+describe("send requests containing JSON data to GitHub cache API endpoints", () => {
   it("should send a request to a valid endpoint", async () => {
-    const { sendCacheApiRequest } = await import("./api.js");
+    const { sendJsonRequest } = await import("./api.js");
 
     process.env["ACTIONS_CACHE_URL"] = "http://localhost:12345/";
     process.env["ACTIONS_RUNTIME_TOKEN"] = "some token";
@@ -44,7 +44,7 @@ describe("send HTTPS requests to GitHub cache API endpoints", () => {
     });
     server.listen(12345);
 
-    const res = await sendCacheApiRequest<{ message: string }>(
+    const res = await sendJsonRequest<{ message: string }>(
       "caches",
       { method: "POST" },
       { message: "some message" },
@@ -56,12 +56,12 @@ describe("send HTTPS requests to GitHub cache API endpoints", () => {
   });
 
   it("should fail to send a request to an invalid endpoint", async () => {
-    const { sendCacheApiRequest } = await import("./api.js");
+    const { sendJsonRequest } = await import("./api.js");
 
     process.env["ACTIONS_CACHE_URL"] = "http://invalid/";
 
     await expect(
-      sendCacheApiRequest("caches", { method: "POST" }),
+      sendJsonRequest("caches", { method: "POST" }, {}),
     ).rejects.toThrow();
   });
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,18 +1,18 @@
 import https from "node:https";
 
 /**
- * Sends an HTTPS request to the GitHub cache API endpoint.
+ * Sends an HTTPS request containing JSON data to the GitHub cache API endpoint.
  *
  * @param resourcePath - The path of the resource to be accessed in the API.
  * @param options - The options for the HTTPS request (e.g., method, headers).
- * @param data - The data to be sent in the request body (optional).
+ * @param data - The JSON data to be sent in the request body.
  * @returns A promise that resolves to a tuple containing the response status
  * code and the parsed response data.
  */
-export async function sendCacheApiRequest<T>(
+export async function sendJsonRequest<T>(
   resourcePath: string,
   options: https.RequestOptions,
-  data?: unknown,
+  data: unknown,
 ): Promise<[number, T]> {
   return new Promise((resolve, reject) => {
     const req = https.request(
@@ -36,10 +36,7 @@ export async function sendCacheApiRequest<T>(
 
     req.on("error", (err) => reject(err));
 
-    if (data !== undefined) {
-      req.write(JSON.stringify(data));
-    }
-
+    req.write(JSON.stringify(data));
     req.end();
   });
 }

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -2,28 +2,39 @@ import type http from "node:http";
 import { jest } from "@jest/globals";
 
 jest.unstable_mockModule("./api.js", () => ({
+  createRequest: jest.fn(),
   handleJsonResponse: jest.fn(),
   sendJsonRequest: jest.fn(),
 }));
 
 describe("reserve caches", () => {
   it("should reserve a cache", async () => {
-    const { handleJsonResponse, sendJsonRequest } = await import("./api.js");
+    const { createRequest, handleJsonResponse, sendJsonRequest } = await import(
+      "./api.js"
+    );
     const { reserveCache } = await import("./cache.js");
 
+    jest
+      .mocked(createRequest)
+      .mockReturnValue("some request" as unknown as http.ClientRequest);
+
     jest.mocked(handleJsonResponse).mockResolvedValue({ cacheId: 32 });
+
     jest.mocked(sendJsonRequest).mockResolvedValue({
       statusCode: 201,
     } as unknown as http.IncomingMessage);
 
     const cacheId = await reserveCache("some-key", "some-version", 1024);
 
+    expect(createRequest).toHaveBeenCalledTimes(1);
+    expect(createRequest).toHaveBeenCalledWith("caches", { method: "POST" });
+
     expect(sendJsonRequest).toHaveBeenCalledTimes(1);
-    expect(sendJsonRequest).toHaveBeenCalledWith(
-      "caches",
-      { method: "POST" },
-      { key: "some-key", version: "some-version", cacheSize: 1024 },
-    );
+    expect(sendJsonRequest).toHaveBeenCalledWith("some request", {
+      key: "some-key",
+      version: "some-version",
+      cacheSize: 1024,
+    });
 
     expect(handleJsonResponse).toHaveBeenCalledTimes(1);
     expect(handleJsonResponse).toHaveBeenCalledWith({ statusCode: 201 });
@@ -32,8 +43,12 @@ describe("reserve caches", () => {
   });
 
   it("should fail to reserve a cache", async () => {
-    const { sendJsonRequest } = await import("./api.js");
+    const { createRequest, sendJsonRequest } = await import("./api.js");
     const { reserveCache } = await import("./cache.js");
+
+    jest
+      .mocked(createRequest)
+      .mockReturnValue("some request" as unknown as http.ClientRequest);
 
     jest.mocked(sendJsonRequest).mockResolvedValue({
       statusCode: 500,

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -1,20 +1,20 @@
 import { jest } from "@jest/globals";
 
 jest.unstable_mockModule("./api.js", () => ({
-  sendCacheApiRequest: jest.fn(),
+  sendJsonRequest: jest.fn(),
 }));
 
 describe("reserve caches", () => {
   it("should reserve a cache", async () => {
-    const { sendCacheApiRequest } = await import("./api.js");
+    const { sendJsonRequest } = await import("./api.js");
     const { reserveCache } = await import("./cache.js");
 
-    jest.mocked(sendCacheApiRequest).mockResolvedValue([201, { cacheId: 32 }]);
+    jest.mocked(sendJsonRequest).mockResolvedValue([201, { cacheId: 32 }]);
 
     const cacheId = await reserveCache("some-key", "some-version", 1024);
 
-    expect(sendCacheApiRequest).toHaveBeenCalledTimes(1);
-    expect(sendCacheApiRequest).toHaveBeenCalledWith(
+    expect(sendJsonRequest).toHaveBeenCalledTimes(1);
+    expect(sendJsonRequest).toHaveBeenCalledWith(
       "caches",
       { method: "POST" },
       { key: "some-key", version: "some-version", cacheSize: 1024 },
@@ -24,10 +24,10 @@ describe("reserve caches", () => {
   });
 
   it("should fail to reserve a cache", async () => {
-    const { sendCacheApiRequest } = await import("./api.js");
+    const { sendJsonRequest } = await import("./api.js");
     const { reserveCache } = await import("./cache.js");
 
-    jest.mocked(sendCacheApiRequest).mockResolvedValue([409, { cacheId: 32 }]);
+    jest.mocked(sendJsonRequest).mockResolvedValue([409, { cacheId: 32 }]);
 
     await expect(
       reserveCache("some-key", "some-version", 1024),

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -1,15 +1,20 @@
+import type http from "node:http";
 import { jest } from "@jest/globals";
 
 jest.unstable_mockModule("./api.js", () => ({
+  handleJsonResponse: jest.fn(),
   sendJsonRequest: jest.fn(),
 }));
 
 describe("reserve caches", () => {
   it("should reserve a cache", async () => {
-    const { sendJsonRequest } = await import("./api.js");
+    const { handleJsonResponse, sendJsonRequest } = await import("./api.js");
     const { reserveCache } = await import("./cache.js");
 
-    jest.mocked(sendJsonRequest).mockResolvedValue([201, { cacheId: 32 }]);
+    jest.mocked(handleJsonResponse).mockResolvedValue({ cacheId: 32 });
+    jest.mocked(sendJsonRequest).mockResolvedValue({
+      statusCode: 201,
+    } as unknown as http.IncomingMessage);
 
     const cacheId = await reserveCache("some-key", "some-version", 1024);
 
@@ -20,6 +25,9 @@ describe("reserve caches", () => {
       { key: "some-key", version: "some-version", cacheSize: 1024 },
     );
 
+    expect(handleJsonResponse).toHaveBeenCalledTimes(1);
+    expect(handleJsonResponse).toHaveBeenCalledWith({ statusCode: 201 });
+
     expect(cacheId).toBe(32);
   });
 
@@ -27,10 +35,12 @@ describe("reserve caches", () => {
     const { sendJsonRequest } = await import("./api.js");
     const { reserveCache } = await import("./cache.js");
 
-    jest.mocked(sendJsonRequest).mockResolvedValue([409, { cacheId: 32 }]);
+    jest.mocked(sendJsonRequest).mockResolvedValue({
+      statusCode: 500,
+    } as unknown as http.IncomingMessage);
 
     await expect(
       reserveCache("some-key", "some-version", 1024),
-    ).rejects.toThrow("failed to reserve cache: 409");
+    ).rejects.toThrow("failed to reserve cache: 500");
   });
 });

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,4 @@
-import { handleJsonResponse, sendJsonRequest } from "./api.js";
+import { createRequest, handleJsonResponse, sendJsonRequest } from "./api.js";
 
 /**
  * Reserve a cache with the specified key, version, and size.
@@ -13,11 +13,8 @@ export async function reserveCache(
   version: string,
   size: number,
 ): Promise<number> {
-  const res = await sendJsonRequest(
-    "caches",
-    { method: "POST" },
-    { key, version, cacheSize: size },
-  );
+  const req = createRequest("caches", { method: "POST" });
+  const res = await sendJsonRequest(req, { key, version, cacheSize: size });
   if (res.statusCode !== 201) {
     throw new Error(`failed to reserve cache: ${res.statusCode}}`);
   }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,4 @@
-import { sendCacheApiRequest } from "./api.js";
+import { sendJsonRequest } from "./api.js";
 
 /**
  * Reserve a cache with the specified key, version, and size.
@@ -13,7 +13,7 @@ export async function reserveCache(
   version: string,
   size: number,
 ): Promise<number> {
-  const [status, { cacheId }] = await sendCacheApiRequest<{
+  const [status, { cacheId }] = await sendJsonRequest<{
     cacheId: number;
   }>("caches", { method: "POST" }, { key, version, cacheSize: size });
   if (status !== 201) {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,4 @@
-import { sendJsonRequest } from "./api.js";
+import { handleJsonResponse, sendJsonRequest } from "./api.js";
 
 /**
  * Reserve a cache with the specified key, version, and size.
@@ -13,11 +13,14 @@ export async function reserveCache(
   version: string,
   size: number,
 ): Promise<number> {
-  const [status, { cacheId }] = await sendJsonRequest<{
-    cacheId: number;
-  }>("caches", { method: "POST" }, { key, version, cacheSize: size });
-  if (status !== 201) {
-    throw new Error(`failed to reserve cache: ${status}}`);
+  const res = await sendJsonRequest(
+    "caches",
+    { method: "POST" },
+    { key, version, cacheSize: size },
+  );
+  if (res.statusCode !== 201) {
+    throw new Error(`failed to reserve cache: ${res.statusCode}}`);
   }
+  const { cacheId } = (await handleJsonResponse(res)) as { cacheId: number };
   return cacheId;
 }


### PR DESCRIPTION
This pull request resolves #19 by separating the `sendCacheApiRequest` function into the following distinct functions:
- `createRequest`: Responsible for creating an HTTPS request object for the GitHub cache API endpoint.
- `sendJsonRequest`: Handles sending the HTTPS request object along with JSON data.
- `handleJsonResponse`: Manages the processing of an HTTPS response object.

Additionally, this change updates any functions that were previously using the `sendCacheApiRequest` function to utilize these new functions instead.