### PR TITLE
Add Function to Handle Error Response

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -75,6 +75,16 @@ async function handleJsonResponse(res) {
         });
     });
 }
+/**
+ * Handles an HTTPS response containing error data.
+ *
+ * @param res - The HTTPS response object.
+ * @returns A promise that resolves to an error object.
+ */
+async function handleErrorResponse(res) {
+    const data = (await handleJsonResponse(res));
+    return new Error(data.message);
+}
 
 /**
  * Reserve a cache with the specified key, version, and size.
@@ -88,7 +98,7 @@ async function reserveCache(key, version, size) {
     const req = createRequest("caches", { method: "POST" });
     const res = await sendJsonRequest(req, { key, version, cacheSize: size });
     if (res.statusCode !== 201) {
-        throw new Error(`failed to reserve cache: ${res.statusCode}}`);
+        throw await handleErrorResponse(res);
     }
     const { cacheId } = (await handleJsonResponse(res));
     return cacheId;

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -106,4 +106,27 @@ describe("handle responses containing JSON data", () => {
   });
 });
 
+describe("handle responses containing error data", () => {
+  it("should handle a response", async () => {
+    const { createRequest, handleErrorResponse } = await import("./api.js");
+
+    serverHandler = (req, res) => {
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ message: "some error" }));
+      return true;
+    };
+
+    const req = createRequest("caches", { method: "GET" });
+
+    const res = await new Promise<http.IncomingMessage>((resolve, reject) => {
+      req.on("response", (res) => resolve(res));
+      req.on("error", (err) => reject(err));
+      req.end();
+    });
+
+    const err = await handleErrorResponse(res);
+    expect(err.message).toBe("some error");
+  });
+});
+
 afterAll(() => server.close());

--- a/src/api.ts
+++ b/src/api.ts
@@ -65,3 +65,16 @@ export async function handleJsonResponse(
     });
   });
 }
+
+/**
+ * Handles an HTTPS response containing error data.
+ *
+ * @param res - The HTTPS response object.
+ * @returns A promise that resolves to an error object.
+ */
+export async function handleErrorResponse(
+  res: http.IncomingMessage,
+): Promise<Error> {
+  const data = (await handleJsonResponse(res)) as { message: string };
+  return new Error(data.message);
+}

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -3,6 +3,7 @@ import { jest } from "@jest/globals";
 
 jest.unstable_mockModule("./api.js", () => ({
   createRequest: jest.fn(),
+  handleErrorResponse: jest.fn(),
   handleJsonResponse: jest.fn(),
   sendJsonRequest: jest.fn(),
 }));
@@ -43,12 +44,15 @@ describe("reserve caches", () => {
   });
 
   it("should fail to reserve a cache", async () => {
-    const { createRequest, sendJsonRequest } = await import("./api.js");
+    const { createRequest, handleErrorResponse, sendJsonRequest } =
+      await import("./api.js");
     const { reserveCache } = await import("./cache.js");
 
     jest
       .mocked(createRequest)
       .mockReturnValue("some request" as unknown as http.ClientRequest);
+
+    jest.mocked(handleErrorResponse).mockResolvedValue(new Error("some error"));
 
     jest.mocked(sendJsonRequest).mockResolvedValue({
       statusCode: 500,
@@ -56,6 +60,6 @@ describe("reserve caches", () => {
 
     await expect(
       reserveCache("some-key", "some-version", 1024),
-    ).rejects.toThrow("failed to reserve cache: 500");
+    ).rejects.toThrow("some error");
   });
 });

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,9 @@
-import { createRequest, handleJsonResponse, sendJsonRequest } from "./api.js";
+import {
+  createRequest,
+  handleJsonResponse,
+  handleErrorResponse,
+  sendJsonRequest,
+} from "./api.js";
 
 /**
  * Reserve a cache with the specified key, version, and size.
@@ -16,7 +21,7 @@ export async function reserveCache(
   const req = createRequest("caches", { method: "POST" });
   const res = await sendJsonRequest(req, { key, version, cacheSize: size });
   if (res.statusCode !== 201) {
-    throw new Error(`failed to reserve cache: ${res.statusCode}}`);
+    throw await handleErrorResponse(res);
   }
   const { cacheId } = (await handleJsonResponse(res)) as { cacheId: number };
   return cacheId;


### PR DESCRIPTION
This pull request resolves #21 by adding a new `handleErrorResponse` function, along with its associated tests, and integrates it into the `reserveCache` function.