### PR TITLE
Simplify Tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,4 +8,10 @@ export default [
   {
     ignores: [".*", "dist"],
   },
+  {
+    files: ["**/*.test.ts"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+    },
+  },
 ];

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -1,65 +1,67 @@
-import type http from "node:http";
 import { jest } from "@jest/globals";
 
+const createRequest = jest.fn();
+const handleErrorResponse = jest.fn();
+const handleJsonResponse = jest.fn();
+const sendJsonRequest = jest.fn();
+
 jest.unstable_mockModule("./api.js", () => ({
-  createRequest: jest.fn(),
-  handleErrorResponse: jest.fn(),
-  handleJsonResponse: jest.fn(),
-  sendJsonRequest: jest.fn(),
+  createRequest,
+  handleErrorResponse,
+  handleJsonResponse,
+  sendJsonRequest,
 }));
 
 describe("reserve caches", () => {
+  beforeAll(() => {
+    createRequest.mockImplementation((resourcePath, options) => {
+      expect(resourcePath).toBe("caches");
+      expect(options).toEqual({ method: "POST" });
+      return "some request";
+    });
+  });
+
   it("should reserve a cache", async () => {
-    const { createRequest, handleJsonResponse, sendJsonRequest } = await import(
-      "./api.js"
-    );
     const { reserveCache } = await import("./cache.js");
 
-    jest
-      .mocked(createRequest)
-      .mockReturnValue("some request" as unknown as http.ClientRequest);
-
-    jest.mocked(handleJsonResponse).mockResolvedValue({ cacheId: 32 });
-
-    jest.mocked(sendJsonRequest).mockResolvedValue({
-      statusCode: 201,
-    } as unknown as http.IncomingMessage);
-
-    const cacheId = await reserveCache("some-key", "some-version", 1024);
-
-    expect(createRequest).toHaveBeenCalledTimes(1);
-    expect(createRequest).toHaveBeenCalledWith("caches", { method: "POST" });
-
-    expect(sendJsonRequest).toHaveBeenCalledTimes(1);
-    expect(sendJsonRequest).toHaveBeenCalledWith("some request", {
-      key: "some-key",
-      version: "some-version",
-      cacheSize: 1024,
+    sendJsonRequest.mockImplementation(async (req, data) => {
+      expect(req).toBe("some request");
+      expect(data).toEqual({
+        key: "some-key",
+        version: "some-version",
+        cacheSize: 1024,
+      });
+      return { statusCode: 201 };
     });
 
-    expect(handleJsonResponse).toHaveBeenCalledTimes(1);
-    expect(handleJsonResponse).toHaveBeenCalledWith({ statusCode: 201 });
+    handleJsonResponse.mockImplementation(async (res) => {
+      expect(res).toEqual({ statusCode: 201 });
+      return { cacheId: 32 };
+    });
 
+    const cacheId = await reserveCache("some-key", "some-version", 1024);
     expect(cacheId).toBe(32);
   });
 
   it("should fail to reserve a cache", async () => {
-    const { createRequest, handleErrorResponse, sendJsonRequest } =
-      await import("./api.js");
     const { reserveCache } = await import("./cache.js");
 
-    jest
-      .mocked(createRequest)
-      .mockReturnValue("some request" as unknown as http.ClientRequest);
+    sendJsonRequest.mockImplementation(async (req, data) => {
+      expect(req).toBe("some request");
+      expect(data).toEqual({
+        key: "some-key",
+        version: "some-version",
+        cacheSize: 1024,
+      });
+      return { statusCode: 500 };
+    });
 
-    jest.mocked(handleErrorResponse).mockResolvedValue(new Error("some error"));
+    handleErrorResponse.mockImplementation(async (res) => {
+      expect(res).toEqual({ statusCode: 500 });
+      return new Error("some error");
+    });
 
-    jest.mocked(sendJsonRequest).mockResolvedValue({
-      statusCode: 500,
-    } as unknown as http.IncomingMessage);
-
-    await expect(
-      reserveCache("some-key", "some-version", 1024),
-    ).rejects.toThrow("some error");
+    const prom = reserveCache("some-key", "some-version", 1024);
+    await expect(prom).rejects.toThrow("some error");
   });
 });


### PR DESCRIPTION
This pull request resolves #23 by simplifying the tests in the project as follows:
- Disables the [`@typescript-eslint/no-explicit-any`](https://typescript-eslint.io/rules/no-explicit-any/) rule in test files.
- Refactors module mocking in the `cache.test.ts` file.
- Introduces a new mocked request and response object in the `api.test.ts` file, replacing the need for real HTTPS server creation.