### PR TITLE
Add Function to Handle HTTPS Response Containing Raw Data

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -77,8 +77,9 @@ async function handleResponse(res) {
 /**
  * Handles an HTTPS response containing JSON data.
  *
+ * @typeParam T - The expected type of the parsed JSON data.
  * @param res - The HTTPS response object.
- * @returns A promise that resolves to the parsed JSON data.
+ * @returns A promise that resolves to the parsed JSON data of type T.
  */
 async function handleJsonResponse(res) {
     const data = await handleResponse(res);
@@ -91,8 +92,8 @@ async function handleJsonResponse(res) {
  * @returns A promise that resolves to an error object.
  */
 async function handleErrorResponse(res) {
-    const data = (await handleJsonResponse(res));
-    return new Error(data.message);
+    const { message } = await handleJsonResponse(res);
+    return new Error(message);
 }
 
 /**
@@ -109,7 +110,7 @@ async function reserveCache(key, version, size) {
     if (res.statusCode !== 201) {
         throw await handleErrorResponse(res);
     }
-    const { cacheId } = (await handleJsonResponse(res));
+    const { cacheId } = await handleJsonResponse(res);
     return cacheId;
 }
 

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -61,18 +61,28 @@ async function sendJsonRequest(req, data) {
     });
 }
 /**
+ * Handles an HTTPS response containing raw data.
+ *
+ * @param res - The HTTPS response object.
+ * @returns A promise that resolves to the raw data as a string.
+ */
+async function handleResponse(res) {
+    return new Promise((resolve, reject) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk.toString()));
+        res.on("end", () => resolve(data));
+        res.on("error", (err) => reject(err));
+    });
+}
+/**
  * Handles an HTTPS response containing JSON data.
  *
  * @param res - The HTTPS response object.
  * @returns A promise that resolves to the parsed JSON data.
  */
 async function handleJsonResponse(res) {
-    return new Promise((resolve, reject) => {
-        let data = "";
-        res.on("data", (chunk) => (data += chunk.toString()));
-        res.on("end", () => resolve(JSON.parse(data)));
-        res.on("error", (err) => reject(err));
-    });
+    const data = await handleResponse(res);
+    return JSON.parse(data);
 }
 /**
  * Handles an HTTPS response containing error data.

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -181,6 +181,31 @@ describe("send HTTPS requests containing binary streams", () => {
   });
 });
 
+describe("handle HTTPS responses containing raw data", () => {
+  it("should handle an HTTPS response", async () => {
+    const { handleResponse } = await import("./api.js");
+
+    const res = new MockedResponse();
+    const prom = handleResponse(res as any);
+
+    res.write("some data");
+    res.end();
+
+    await expect(prom).resolves.toEqual("some data");
+  });
+
+  it("should fail to handle an HTTPS response", async () => {
+    const { handleResponse } = await import("./api.js");
+
+    const res = new MockedResponse();
+    const prom = handleResponse(res as any);
+
+    res.error(new Error("some error"));
+
+    await expect(prom).rejects.toThrow("some error");
+  });
+});
+
 describe("handle HTTPS responses containing JSON data", () => {
   it("should handle an HTTPS response", async () => {
     const { handleJsonResponse } = await import("./api.js");
@@ -192,17 +217,6 @@ describe("handle HTTPS responses containing JSON data", () => {
     res.end();
 
     await expect(prom).resolves.toEqual({ message: "some message" });
-  });
-
-  it("should fail to handle an HTTPS response", async () => {
-    const { handleJsonResponse } = await import("./api.js");
-
-    const res = new MockedResponse();
-    const prom = handleJsonResponse(res as any);
-
-    res.error(new Error("some error"));
-
-    await expect(prom).rejects.toThrow("some error");
   });
 });
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -76,6 +76,23 @@ export async function sendStreamRequest(
 }
 
 /**
+ * Handles an HTTPS response containing raw data.
+ *
+ * @param res - The HTTPS response object.
+ * @returns A promise that resolves to the raw data as a string.
+ */
+export async function handleResponse(
+  res: http.IncomingMessage,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    res.on("data", (chunk) => (data += chunk.toString()));
+    res.on("end", () => resolve(data));
+    res.on("error", (err) => reject(err));
+  });
+}
+
+/**
  * Handles an HTTPS response containing JSON data.
  *
  * @param res - The HTTPS response object.
@@ -84,12 +101,8 @@ export async function sendStreamRequest(
 export async function handleJsonResponse(
   res: http.IncomingMessage,
 ): Promise<unknown> {
-  return new Promise((resolve, reject) => {
-    let data = "";
-    res.on("data", (chunk) => (data += chunk.toString()));
-    res.on("end", () => resolve(JSON.parse(data)));
-    res.on("error", (err) => reject(err));
-  });
+  const data = await handleResponse(res);
+  return JSON.parse(data);
 }
 
 /**

--- a/src/api.ts
+++ b/src/api.ts
@@ -95,12 +95,13 @@ export async function handleResponse(
 /**
  * Handles an HTTPS response containing JSON data.
  *
+ * @typeParam T - The expected type of the parsed JSON data.
  * @param res - The HTTPS response object.
- * @returns A promise that resolves to the parsed JSON data.
+ * @returns A promise that resolves to the parsed JSON data of type T.
  */
-export async function handleJsonResponse(
+export async function handleJsonResponse<T>(
   res: http.IncomingMessage,
-): Promise<unknown> {
+): Promise<T> {
   const data = await handleResponse(res);
   return JSON.parse(data);
 }
@@ -114,6 +115,6 @@ export async function handleJsonResponse(
 export async function handleErrorResponse(
   res: http.IncomingMessage,
 ): Promise<Error> {
-  const data = (await handleJsonResponse(res)) as { message: string };
-  return new Error(data.message);
+  const { message } = await handleJsonResponse<{ message: string }>(res);
+  return new Error(message);
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -23,6 +23,6 @@ export async function reserveCache(
   if (res.statusCode !== 201) {
     throw await handleErrorResponse(res);
   }
-  const { cacheId } = (await handleJsonResponse(res)) as { cacheId: number };
+  const { cacheId } = await handleJsonResponse<{ cacheId: number }>(res);
   return cacheId;
 }


### PR DESCRIPTION
This pull request resolves #29 by adding a new `handleResponse` function, separating it from the `handleJsonResponse` function without the JSON parsing part. It also modifies the `handleJsonResponse` function to return a type parameter and updates the tests accordingly.