### PR TITLE
Modify Action to Check Cache Before Uploading

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,14 @@ jobs:
         shell: bash
         run: echo "some value" >> file.txt
 
-      - name: Reserve Cache
+      - name: Save Cache
+        uses: ./cache-action
+        with:
+          key: some-key-${{ matrix.os }}
+          version: ${{ github.run_id }}
+          file: file.txt
+
+      - name: Save Cache Again
         uses: ./cache-action
         with:
           key: some-key-${{ matrix.os }}

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: Cache Action
 author: Alfi Maulana
-description: Reserve caches
+description: Save caches
 branding:
   icon: archive
   color: black

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -156,7 +156,7 @@ async function uploadCache(id, file, fileSize) {
     if (res.statusCode !== 204) {
         throw await handleErrorResponse(res);
     }
-    handleResponse(res);
+    await handleResponse(res);
 }
 /**
  * Commits a cache with the specified ID.
@@ -171,7 +171,7 @@ async function commitCache(id, size) {
     if (res.statusCode !== 204) {
         throw await handleErrorResponse(res);
     }
-    handleResponse(res);
+    await handleResponse(res);
 }
 
 try {

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -126,6 +126,29 @@ async function handleErrorResponse(res) {
 }
 
 /**
+ * Retrieves cache information for the specified key and version.
+ *
+ * @param key - The cache key.
+ * @param version - The cache version.
+ * @returns A promise that resolves with the cache information or null if not found.
+ */
+async function getCache(key, version) {
+    const req = createRequest(`cache?keys=${key}&version=${version}`, {
+        method: "GET",
+    });
+    const res = await sendRequest(req);
+    switch (res.statusCode) {
+        case 200:
+            return await handleJsonResponse(res);
+        // Cache not found, return null.
+        case 204:
+            await handleResponse(res);
+            return null;
+        default:
+            throw await handleErrorResponse(res);
+    }
+}
+/**
  * Reserves a cache with the specified key, version, and size.
  *
  * @param key - The key of the cache to reserve.
@@ -175,10 +198,18 @@ async function commitCache(id, size) {
 }
 
 try {
+    const key = getInput("key");
+    const version = getInput("version");
+    logInfo("Getting cache...");
+    const cache = await getCache(key, version);
+    if (cache !== null) {
+        logInfo("Cache exists, skipping upload...");
+        process.exit(0);
+    }
     const filePath = getInput("file");
     const fileSize = fs.statSync(filePath).size;
     logInfo("Reserving cache...");
-    const cacheId = await reserveCache(getInput("key"), getInput("version"), fileSize);
+    const cacheId = await reserveCache(key, version, fileSize);
     logInfo(`Cache reserved with id: ${cacheId}`);
     logInfo("Uploading cache...");
     const file = fs.createReadStream(filePath, {

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -5,6 +5,7 @@ const handleErrorResponse = jest.fn();
 const handleJsonResponse = jest.fn();
 const handleResponse = jest.fn();
 const sendJsonRequest = jest.fn();
+const sendRequest = jest.fn();
 const sendStreamRequest = jest.fn();
 
 jest.unstable_mockModule("./api.js", () => ({
@@ -13,6 +14,7 @@ jest.unstable_mockModule("./api.js", () => ({
   handleJsonResponse,
   handleResponse,
   sendJsonRequest,
+  sendRequest,
   sendStreamRequest,
 }));
 

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -18,6 +18,70 @@ jest.unstable_mockModule("./api.js", () => ({
   sendStreamRequest,
 }));
 
+describe("retrieve caches", () => {
+  beforeAll(() => {
+    createRequest.mockImplementation((resourcePath, options) => {
+      expect(resourcePath).toBe("cache?keys=some-key&version=some-version");
+      expect(options).toEqual({ method: "GET" });
+      return "some request";
+    });
+  });
+
+  it("should retrieve a cache", async () => {
+    const { getCache } = await import("./cache.js");
+
+    sendRequest.mockImplementation(async (req, data) => {
+      expect(req).toBe("some request");
+      expect(data).toBeUndefined();
+      return { statusCode: 200 };
+    });
+
+    handleJsonResponse.mockImplementation(async (res) => {
+      expect(res).toEqual({ statusCode: 200 });
+      return "some cache";
+    });
+
+    const cache = await getCache("some-key", "some-version");
+    expect(cache).toBe("some cache");
+  });
+
+  it("should retrieve a non-existing cache", async () => {
+    const { getCache } = await import("./cache.js");
+
+    sendRequest.mockImplementation(async (req, data) => {
+      expect(req).toBe("some request");
+      expect(data).toBeUndefined();
+      return { statusCode: 204 };
+    });
+
+    handleResponse.mockImplementation(async (res) => {
+      expect(res).toEqual({ statusCode: 204 });
+      return "";
+    });
+
+    const cache = await getCache("some-key", "some-version");
+    expect(cache).toBeNull();
+  });
+
+  it("should fail to retrieve a cache", async () => {
+    const { getCache } = await import("./cache.js");
+
+    sendRequest.mockImplementation(async (req, data) => {
+      expect(req).toBe("some request");
+      expect(data).toBeUndefined();
+      return { statusCode: 500 };
+    });
+
+    handleErrorResponse.mockImplementation(async (res) => {
+      expect(res).toEqual({ statusCode: 500 });
+      return new Error("some error");
+    });
+
+    const prom = getCache("some-key", "some-version");
+    await expect(prom).rejects.toThrow("some error");
+  });
+});
+
 describe("reserve caches", () => {
   beforeAll(() => {
     createRequest.mockImplementation((resourcePath, options) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,23 @@
 import { getInput, logError, logInfo } from "gha-utils";
 import fs from "node:fs";
-import { commitCache, reserveCache, uploadCache } from "./cache.js";
+import { commitCache, getCache, reserveCache, uploadCache } from "./cache.js";
 
 try {
+  const key = getInput("key");
+  const version = getInput("version");
+
+  logInfo("Getting cache...");
+  const cache = await getCache(key, version);
+  if (cache !== null) {
+    logInfo("Cache exists, skipping upload...");
+    process.exit(0);
+  }
+
   const filePath = getInput("file");
   const fileSize = fs.statSync(filePath).size;
 
   logInfo("Reserving cache...");
-  const cacheId = await reserveCache(
-    getInput("key"),
-    getInput("version"),
-    fileSize,
-  );
+  const cacheId = await reserveCache(key, version, fileSize);
   logInfo(`Cache reserved with id: ${cacheId}`);
 
   logInfo("Uploading cache...");


### PR DESCRIPTION
This pull request resolves #31 by modifying the action to check for the existence of the cache before saving a file as a cache. It also introduces a new `getCache` function, along with corresponding tests.