### PR TITLE
Add Function to Send HTTPS Request Containing Raw Data

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -45,6 +45,22 @@ function createRequest(resourcePath, options) {
     return req;
 }
 /**
+ * Sends an HTTPS request containing raw data.
+ *
+ * @param req - The HTTPS request object.
+ * @param data - The raw data to be sent in the request body.
+ * @returns A promise that resolves to an HTTPS response object.
+ */
+async function sendRequest(req, data) {
+    return new Promise((resolve, reject) => {
+        req.on("response", (res) => resolve(res));
+        req.on("error", (err) => reject(err));
+        if (data !== undefined)
+            req.write(data);
+        req.end();
+    });
+}
+/**
  * Sends an HTTPS request containing JSON data.
  *
  * @param req - The HTTPS request object.
@@ -52,13 +68,8 @@ function createRequest(resourcePath, options) {
  * @returns A promise that resolves to an HTTPS response object.
  */
 async function sendJsonRequest(req, data) {
-    return new Promise((resolve, reject) => {
-        req.setHeader("Content-Type", "application/json");
-        req.on("response", (res) => resolve(res));
-        req.on("error", (err) => reject(err));
-        req.write(JSON.stringify(data));
-        req.end();
-    });
+    req.setHeader("Content-Type", "application/json");
+    return sendRequest(req, JSON.stringify(data));
 }
 /**
  * Sends an HTTPS request containing a binary stream.

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -121,6 +121,32 @@ describe("create HTTPS requests for the GitHub cache API endpoint", () => {
   });
 });
 
+describe("send HTTPS requests containing raw data", () => {
+  it("should send an HTTPS request", async () => {
+    const { sendRequest } = await import("./api.js");
+
+    const req = new MockedRequest();
+    const prom = sendRequest(req as any, "some data");
+
+    req.response("some response");
+
+    await expect(prom).resolves.toBe("some response");
+    expect(req.headers).toEqual({});
+    expect(req.data).toBe("some data");
+  });
+
+  it("should fail to send an HTTPS request", async () => {
+    const { sendRequest } = await import("./api.js");
+
+    const req = new MockedRequest();
+    const prom = sendRequest(req as any);
+
+    req.error(new Error("some error"));
+
+    await expect(prom).rejects.toThrow("some error");
+  });
+});
+
 describe("send HTTPS requests containing JSON data", () => {
   it("should send an HTTPS request", async () => {
     const { sendJsonRequest } = await import("./api.js");
@@ -133,17 +159,6 @@ describe("send HTTPS requests containing JSON data", () => {
     await expect(prom).resolves.toBe("some response");
     expect(req.headers).toEqual({ "Content-Type": "application/json" });
     expect(req.data).toBe(JSON.stringify({ message: "some message" }));
-  });
-
-  it("should fail to send an HTTPS request", async () => {
-    const { sendJsonRequest } = await import("./api.js");
-
-    const req = new MockedRequest();
-    const prom = sendJsonRequest(req as any, {});
-
-    req.error(new Error("some error"));
-
-    await expect(prom).rejects.toThrow("some error");
   });
 });
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -28,6 +28,26 @@ export function createRequest(
 }
 
 /**
+ * Sends an HTTPS request containing raw data.
+ *
+ * @param req - The HTTPS request object.
+ * @param data - The raw data to be sent in the request body.
+ * @returns A promise that resolves to an HTTPS response object.
+ */
+export async function sendRequest(
+  req: http.ClientRequest,
+  data?: string,
+): Promise<http.IncomingMessage> {
+  return new Promise((resolve, reject) => {
+    req.on("response", (res) => resolve(res));
+    req.on("error", (err) => reject(err));
+
+    if (data !== undefined) req.write(data);
+    req.end();
+  });
+}
+
+/**
  * Sends an HTTPS request containing JSON data.
  *
  * @param req - The HTTPS request object.
@@ -38,15 +58,8 @@ export async function sendJsonRequest(
   req: http.ClientRequest,
   data: unknown,
 ): Promise<http.IncomingMessage> {
-  return new Promise((resolve, reject) => {
-    req.setHeader("Content-Type", "application/json");
-
-    req.on("response", (res) => resolve(res));
-    req.on("error", (err) => reject(err));
-
-    req.write(JSON.stringify(data));
-    req.end();
-  });
+  req.setHeader("Content-Type", "application/json");
+  return sendRequest(req, JSON.stringify(data));
 }
 
 /**


### PR DESCRIPTION
This pull request resolves #33 by adding a new `sendRequest` function, separating it from the `sendJsonRequest` function without the JSON stringify part. It also updates the tests accordingly.