### PR TITLE
Modify Action to Restore Cache if It Exists

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,9 +53,17 @@ jobs:
           version: ${{ github.run_id }}
           file: file.txt
 
-      - name: Save Cache Again
+      - name: Remove File
+        shell: bash
+        run: rm file.txt
+
+      - name: Restore Cache
         uses: ./cache-action
         with:
           key: some-key-${{ matrix.os }}
           version: ${{ github.run_id }}
           file: file.txt
+
+      - name: Check File
+        shell: bash
+        run: test "$(cat file.txt)" == "some value"

--- a/action.yml
+++ b/action.yml
@@ -1,18 +1,18 @@
 name: Cache Action
 author: Alfi Maulana
-description: Save caches
+description: Restore and save files to cache
 branding:
   icon: archive
   color: black
 inputs:
   key:
-    description: The key of the cache
+    description: The cache key
     required: true
   version:
-    description: The version of the cache
+    description: The cache version
     required: true
   file:
-    description: The file to cache
+    description: The file to be cached
     required: true
 runs:
   using: node20

--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -1,0 +1,41 @@
+import { jest } from "@jest/globals";
+
+const fs = { createWriteStream: jest.fn() };
+jest.unstable_mockModule("node:fs", () => ({ default: fs }));
+
+const https = { request: jest.fn() };
+jest.unstable_mockModule("node:https", () => ({ default: https }));
+
+const stream = { pipeline: jest.fn() };
+jest.unstable_mockModule("node:stream/promises", () => ({ default: stream }));
+
+const sendRequest = jest.fn();
+jest.unstable_mockModule("./api/https.js", () => ({ sendRequest }));
+
+describe("download files", () => {
+  it("it should download a file", async () => {
+    const { downloadFile } = await import("./download.js");
+
+    https.request.mockImplementation((url: any) => {
+      expect(url).toBe("some URL");
+      return "some request";
+    });
+
+    sendRequest.mockImplementation(async (req: any) => {
+      expect(req).toBe("some request");
+      return "some response";
+    });
+
+    fs.createWriteStream.mockImplementation((path) => {
+      expect(path).toBe("some file path");
+      return "some file stream";
+    });
+
+    stream.pipeline.mockImplementation(async (source, destination) => {
+      expect(source).toBe("some response");
+      expect(destination).toBe("some file stream");
+    });
+
+    await downloadFile("some URL", "some file path");
+  });
+});

--- a/src/download.ts
+++ b/src/download.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+import https from "node:https";
+import stream from "node:stream/promises";
+import { sendRequest } from "./api/https.js";
+
+/**
+ * Downloads a file from the specified URL and saves it to the provided path.
+ *
+ * @param url - The URL of the file to download.
+ * @param savePath - The path where the downloaded file will be saved.
+ * @returns A promise that resolves when the download is complete.
+ */
+export async function downloadFile(
+  url: string,
+  savePath: string,
+): Promise<void> {
+  const req = https.request(url);
+  const res = await sendRequest(req);
+
+  const file = fs.createWriteStream(savePath);
+  await stream.pipeline(res, file);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,18 +8,24 @@ import {
   uploadCache,
 } from "./api/cache.js";
 
+import { downloadFile } from "./download.js";
+
 try {
   const key = getInput("key");
   const version = getInput("version");
+  const filePath = getInput("file");
 
   logInfo("Getting cache...");
   const cache = await getCache(key, version);
   if (cache !== null) {
-    logInfo("Cache exists, skipping upload...");
+    logInfo("Cache exists, restoring...");
+    await downloadFile(cache.archiveLocation, filePath);
+    logInfo("Cache restored");
+
     process.exit(0);
   }
+  logInfo("Cache does not exist, saving...");
 
-  const filePath = getInput("file");
   const fileSize = fs.statSync(filePath).size;
 
   logInfo("Reserving cache...");


### PR DESCRIPTION
This pull request resolves #35 by modifying the action to restore the cache if it exists. It also introduces a new `downloadFile` function for downloading a file from the cache URL and updates the tests accordingly.