### PR TITLE
Separate Restore Cache Function

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -212,16 +212,30 @@ async function downloadFile(url, savePath) {
     await stream.pipeline(res, file);
 }
 
+/**
+ * Restores a file from the cache using the specified key and version.
+ *
+ * @param key - The cache key.
+ * @param version - The cache version.
+ * @param filePath - The path to the file to be restored.
+ * @returns A promise that resolves to a boolean value indicating whether the
+ * file was successfully restored.
+ */
+async function restoreCache(key, version, filePath) {
+    const cache = await getCache(key, version);
+    if (cache === null)
+        return false;
+    await downloadFile(cache.archiveLocation, filePath);
+    return true;
+}
+
 try {
     const key = getInput("key");
     const version = getInput("version");
     const filePath = getInput("file");
-    logInfo("Getting cache...");
-    const cache = await getCache(key, version);
-    if (cache !== null) {
-        logInfo("Cache exists, restoring...");
-        await downloadFile(cache.archiveLocation, filePath);
-        logInfo("Cache restored");
+    logInfo("Restoring cache...");
+    if (await restoreCache(key, version, filePath)) {
+        logInfo("Cache successfully restored");
         process.exit(0);
     }
     logInfo("Cache does not exist, saving...");

--- a/src/api/download.test.ts
+++ b/src/api/download.test.ts
@@ -10,7 +10,7 @@ const stream = { pipeline: jest.fn() };
 jest.unstable_mockModule("node:stream/promises", () => ({ default: stream }));
 
 const sendRequest = jest.fn();
-jest.unstable_mockModule("./api/https.js", () => ({ sendRequest }));
+jest.unstable_mockModule("./https.js", () => ({ sendRequest }));
 
 describe("download files", () => {
   it("it should download a file", async () => {

--- a/src/api/download.ts
+++ b/src/api/download.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import https from "node:https";
 import stream from "node:stream/promises";
-import { sendRequest } from "./api/https.js";
+import { sendRequest } from "./https.js";
 
 /**
  * Downloads a file from the specified URL and saves it to the provided path.

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -1,0 +1,52 @@
+import { jest } from "@jest/globals";
+
+const getCache = jest.fn();
+jest.unstable_mockModule("./api/cache.js", () => ({ getCache }));
+
+const downloadFile = jest.fn();
+jest.unstable_mockModule("./api/download.js", () => ({ downloadFile }));
+
+describe("restore caches", () => {
+  it("it should restore a cache", async () => {
+    const { restoreCache } = await import("./cache.js");
+
+    getCache.mockImplementation(async (key, version) => {
+      expect(key).toBe("some key");
+      expect(version).toBe("some version");
+      return { archiveLocation: "some URL" };
+    });
+
+    downloadFile.mockImplementation(async (url, savePath) => {
+      expect(url).toBe("some URL");
+      expect(savePath).toBe("some file path");
+    });
+
+    const restored = await restoreCache(
+      "some key",
+      "some version",
+      "some file path",
+    );
+    expect(restored).toBe(true);
+  });
+
+  it("it should not restore a cache", async () => {
+    const { restoreCache } = await import("./cache.js");
+
+    getCache.mockImplementation(async (key, version) => {
+      expect(key).toBe("some key");
+      expect(version).toBe("some version");
+      return null;
+    });
+
+    downloadFile.mockImplementation(async () => {
+      throw new Error("some error");
+    });
+
+    const restored = await restoreCache(
+      "some key",
+      "some version",
+      "some file path",
+    );
+    expect(restored).toBe(false);
+  });
+});

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,22 @@
+import { getCache } from "./api/cache.js";
+import { downloadFile } from "./api/download.js";
+
+/**
+ * Restores a file from the cache using the specified key and version.
+ *
+ * @param key - The cache key.
+ * @param version - The cache version.
+ * @param filePath - The path to the file to be restored.
+ * @returns A promise that resolves to a boolean value indicating whether the
+ * file was successfully restored.
+ */
+export async function restoreCache(
+  key: string,
+  version: string,
+  filePath: string,
+): Promise<boolean> {
+  const cache = await getCache(key, version);
+  if (cache === null) return false;
+  await downloadFile(cache.archiveLocation, filePath);
+  return true;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
   uploadCache,
 } from "./api/cache.js";
 
-import { downloadFile } from "./download.js";
+import { downloadFile } from "./api/download.js";
 
 try {
   const key = getInput("key");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,27 +1,16 @@
 import { getInput, logError, logInfo } from "gha-utils";
 import fs from "node:fs";
-
-import {
-  commitCache,
-  getCache,
-  reserveCache,
-  uploadCache,
-} from "./api/cache.js";
-
-import { downloadFile } from "./api/download.js";
+import { commitCache, reserveCache, uploadCache } from "./api/cache.js";
+import { restoreCache } from "./cache.js";
 
 try {
   const key = getInput("key");
   const version = getInput("version");
   const filePath = getInput("file");
 
-  logInfo("Getting cache...");
-  const cache = await getCache(key, version);
-  if (cache !== null) {
-    logInfo("Cache exists, restoring...");
-    await downloadFile(cache.archiveLocation, filePath);
-    logInfo("Cache restored");
-
+  logInfo("Restoring cache...");
+  if (await restoreCache(key, version, filePath)) {
+    logInfo("Cache successfully restored");
     process.exit(0);
   }
   logInfo("Cache does not exist, saving...");


### PR DESCRIPTION
This pull request resolves #42 by introducing a new `restoreCache` function, which has been separated from the code in `src/index.ts` and includes its own tests. Additionally, the `download.ts` file has been moved to the `api` directory, separating it from the `restoreCache` function now located in the `cache.ts` file.