### PR TITLE
Separate Save Cache Function

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -217,7 +217,7 @@ async function downloadFile(url, savePath) {
  *
  * @param key - The cache key.
  * @param version - The cache version.
- * @param filePath - The path to the file to be restored.
+ * @param filePath - The path of the file to be restored.
  * @returns A promise that resolves to a boolean value indicating whether the
  * file was successfully restored.
  */

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -1,13 +1,28 @@
 import { jest } from "@jest/globals";
 
+const fs = {
+  openSync: jest.fn(),
+  createReadStream: jest.fn(),
+  statSync: jest.fn(),
+};
+jest.unstable_mockModule("node:fs", () => ({ default: fs }));
+
+const commitCache = jest.fn();
 const getCache = jest.fn();
-jest.unstable_mockModule("./api/cache.js", () => ({ getCache }));
+const reserveCache = jest.fn();
+const uploadCache = jest.fn();
+jest.unstable_mockModule("./api/cache.js", () => ({
+  commitCache,
+  getCache,
+  reserveCache,
+  uploadCache,
+}));
 
 const downloadFile = jest.fn();
 jest.unstable_mockModule("./api/download.js", () => ({ downloadFile }));
 
-describe("restore caches", () => {
-  it("it should restore a cache", async () => {
+describe("restore files from caches", () => {
+  it("it should restore a file from a cache", async () => {
     const { restoreCache } = await import("./cache.js");
 
     getCache.mockImplementation(async (key, version) => {
@@ -48,5 +63,53 @@ describe("restore caches", () => {
       "some file path",
     );
     expect(restored).toBe(false);
+  });
+});
+
+describe("save files to caches", () => {
+  it("it should save a file to a cache", async () => {
+    const { saveCache } = await import("./cache.js");
+
+    fs.statSync.mockImplementation((path) => {
+      expect(path).toBe("some file path");
+      return { size: 1024 };
+    });
+
+    reserveCache.mockImplementation(async (key, version, size) => {
+      expect(key).toBe("some key");
+      expect(version).toBe("some version");
+      expect(size).toBe(1024);
+      return 32;
+    });
+
+    fs.openSync.mockImplementation((path, flags) => {
+      expect(path).toBe("some file path");
+      expect(flags).toBe("r");
+      return "some file";
+    });
+
+    fs.createReadStream.mockImplementation((path, option) => {
+      expect(path).toBe("some file path");
+      expect(option).toEqual({
+        fd: "some file",
+        autoClose: false,
+        start: 0,
+        end: 1024,
+      });
+      return "some file stream";
+    });
+
+    uploadCache.mockImplementation(async (id, file, fileSize) => {
+      expect(id).toBe(32);
+      expect(file).toBe("some file stream");
+      expect(fileSize).toBe(1024);
+    });
+
+    commitCache.mockImplementation(async (id, size) => {
+      expect(id).toBe(32);
+      expect(size).toBe(1024);
+    });
+
+    await saveCache("some key", "some version", "some file path");
   });
 });

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,12 @@
-import { getCache } from "./api/cache.js";
+import fs from "node:fs";
+
+import {
+  commitCache,
+  getCache,
+  reserveCache,
+  uploadCache,
+} from "./api/cache.js";
+
 import { downloadFile } from "./api/download.js";
 
 /**
@@ -6,7 +14,7 @@ import { downloadFile } from "./api/download.js";
  *
  * @param key - The cache key.
  * @param version - The cache version.
- * @param filePath - The path to the file to be restored.
+ * @param filePath - The path of the file to be restored.
  * @returns A promise that resolves to a boolean value indicating whether the
  * file was successfully restored.
  */
@@ -19,4 +27,31 @@ export async function restoreCache(
   if (cache === null) return false;
   await downloadFile(cache.archiveLocation, filePath);
   return true;
+}
+
+/**
+ * Saves a file to the cache using the specified key and version.
+ *
+ * @param key - The cache key.
+ * @param version - The cache version.
+ * @param filePath - The path of the file to be saved.
+ * @returns A promise that resolves when the file has been successfully saved.
+ */
+export async function saveCache(
+  key: string,
+  version: string,
+  filePath: string,
+): Promise<void> {
+  const fileSize = fs.statSync(filePath).size;
+  const cacheId = await reserveCache(key, version, fileSize);
+
+  const file = fs.createReadStream(filePath, {
+    fd: fs.openSync(filePath, "r"),
+    autoClose: false,
+    start: 0,
+    end: fileSize,
+  });
+  await uploadCache(cacheId, file, fileSize);
+
+  await commitCache(cacheId, fileSize);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { getInput, logError, logInfo } from "gha-utils";
-import fs from "node:fs";
-import { commitCache, reserveCache, uploadCache } from "./api/cache.js";
-import { restoreCache } from "./cache.js";
+import { restoreCache, saveCache } from "./cache.js";
 
 try {
   const key = getInput("key");
@@ -13,27 +11,10 @@ try {
     logInfo("Cache successfully restored");
     process.exit(0);
   }
+
   logInfo("Cache does not exist, saving...");
-
-  const fileSize = fs.statSync(filePath).size;
-
-  logInfo("Reserving cache...");
-  const cacheId = await reserveCache(key, version, fileSize);
-  logInfo(`Cache reserved with id: ${cacheId}`);
-
-  logInfo("Uploading cache...");
-  const file = fs.createReadStream(filePath, {
-    fd: fs.openSync(filePath, "r"),
-    autoClose: false,
-    start: 0,
-    end: fileSize,
-  });
-  await uploadCache(cacheId, file, fileSize);
-  logInfo("Cache uploaded");
-
-  logInfo("Commiting cache...");
-  await commitCache(cacheId, fileSize);
-  logInfo("Cache committed");
+  await saveCache(key, version, filePath);
+  logInfo("Cache successfully saved");
 } catch (err) {
   logError(err);
   process.exit(1);


### PR DESCRIPTION
This pull request resolves #45 by introducing a new `saveCache` function, which has been separated from the code in `src/index.ts` and includes its own tests.