### PR TITLE
Display Status Code When Handling HTTPS Error Responses

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -132,7 +132,7 @@ async function handleJsonResponse(res) {
  */
 async function handleErrorResponse(res) {
     const { message } = await handleJsonResponse(res);
-    return new Error(message);
+    return new Error(`${message} (${res.statusCode})`);
 }
 
 /**

--- a/src/api/https.test.ts
+++ b/src/api/https.test.ts
@@ -75,7 +75,14 @@ class MockedReadable {
 }
 
 class MockedResponse extends MockedReadable {
+  statusCode: number | undefined;
+
   #onError?: (err: Error) => void;
+
+  constructor(statusCode?: number) {
+    super();
+    this.statusCode = statusCode;
+  }
 
   on(event: string, callback: any): void {
     switch (event) {
@@ -239,12 +246,12 @@ describe("handle HTTPS responses containing error data", () => {
   it("should handle an HTTPS response", async () => {
     const { handleErrorResponse } = await import("./https.js");
 
-    const res = new MockedResponse();
+    const res = new MockedResponse(500);
     const prom = handleErrorResponse(res as any);
 
     res.write(JSON.stringify({ message: "some error" }));
     res.end();
 
-    await expect(prom).resolves.toEqual(new Error("some error"));
+    await expect(prom).resolves.toEqual(new Error("some error (500)"));
   });
 });

--- a/src/api/https.ts
+++ b/src/api/https.ts
@@ -130,5 +130,5 @@ export async function handleErrorResponse(
   res: http.IncomingMessage,
 ): Promise<Error> {
   const { message } = await handleJsonResponse<{ message: string }>(res);
-  return new Error(message);
+  return new Error(`${message} (${res.statusCode})`);
 }


### PR DESCRIPTION
This pull request resolves #58 by modifying the `handleErrorResponse` function to display the status code when handling HTTPS error responses.