### PR TITLE
Skip Attempting to Save Cache if It Already Exists

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -164,16 +164,24 @@ async function getCache(key, version) {
  * @param key - The key of the cache to reserve.
  * @param version - The version of the cache to reserve.
  * @param size - The size of the cache to reserve, in bytes.
- * @returns A promise that resolves with the reserved cache ID.
+ * @returns A promise that resolves to the reserved cache ID, or null if the
+ * cache is already reserved.
  */
 async function reserveCache(key, version, size) {
     const req = createRequest("caches", { method: "POST" });
     const res = await sendJsonRequest(req, { key, version, cacheSize: size });
-    if (res.statusCode !== 201) {
-        throw await handleErrorResponse(res);
+    switch (res.statusCode) {
+        case 201: {
+            const { cacheId } = await handleJsonResponse(res);
+            return cacheId;
+        }
+        // Cache already reserved, return null.
+        case 409:
+            await handleResponse(res);
+            return null;
+        default:
+            throw await handleErrorResponse(res);
     }
-    const { cacheId } = await handleJsonResponse(res);
-    return cacheId;
 }
 /**
  * Uploads a file to a cache with the specified ID.
@@ -248,14 +256,16 @@ async function restoreCache(key, version, filePath) {
 async function saveCache(key, version, filePath) {
     const fileSize = fs.statSync(filePath).size;
     const cacheId = await reserveCache(key, version, fileSize);
-    const file = fs.createReadStream(filePath, {
-        fd: fs.openSync(filePath, "r"),
-        autoClose: false,
-        start: 0,
-        end: fileSize,
-    });
-    await uploadCache(cacheId, file, fileSize);
-    await commitCache(cacheId, fileSize);
+    if (cacheId !== null) {
+        const file = fs.createReadStream(filePath, {
+            fd: fs.openSync(filePath, "r"),
+            autoClose: false,
+            start: 0,
+            end: fileSize,
+        });
+        await uploadCache(cacheId, file, fileSize);
+        await commitCache(cacheId, fileSize);
+    }
 }
 
 try {

--- a/src/api/cache.test.ts
+++ b/src/api/cache.test.ts
@@ -45,7 +45,7 @@ describe("retrieve caches", () => {
     expect(cache).toBe("some cache");
   });
 
-  it("should retrieve a non-existing cache", async () => {
+  it("should not retrieve a non-existing cache", async () => {
     const { getCache } = await import("./cache.js");
 
     sendRequest.mockImplementation(async (req, data) => {
@@ -111,6 +111,28 @@ describe("reserve caches", () => {
 
     const cacheId = await reserveCache("some-key", "some-version", 1024);
     expect(cacheId).toBe(32);
+  });
+
+  it("should not reserve a reserved cache", async () => {
+    const { reserveCache } = await import("./cache.js");
+
+    sendJsonRequest.mockImplementation(async (req, data) => {
+      expect(req).toBe("some request");
+      expect(data).toEqual({
+        key: "some-key",
+        version: "some-version",
+        cacheSize: 1024,
+      });
+      return { statusCode: 409 };
+    });
+
+    handleResponse.mockImplementation(async (res) => {
+      expect(res).toEqual({ statusCode: 409 });
+      return "";
+    });
+
+    const cacheId = await reserveCache("some-key", "some-version", 1024);
+    expect(cacheId).toBeNull();
   });
 
   it("should fail to reserve a cache", async () => {

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -44,7 +44,7 @@ describe("restore files from caches", () => {
     expect(restored).toBe(true);
   });
 
-  it("it should not restore a cache", async () => {
+  it("it should not restore a file from a cache", async () => {
     const { restoreCache } = await import("./cache.js");
 
     getCache.mockImplementation(async (key, version) => {
@@ -110,6 +110,26 @@ describe("save files to caches", () => {
       expect(size).toBe(1024);
     });
 
-    await saveCache("some key", "some version", "some file path");
+    const saved = await saveCache("some key", "some version", "some file path");
+    expect(saved).toBe(true);
+  });
+
+  it("it should not save a file to a cache", async () => {
+    const { saveCache } = await import("./cache.js");
+
+    fs.statSync.mockImplementation((path) => {
+      expect(path).toBe("some file path");
+      return { size: 1024 };
+    });
+
+    reserveCache.mockImplementation(async (key, version, size) => {
+      expect(key).toBe("some key");
+      expect(version).toBe("some version");
+      expect(size).toBe(1024);
+      return null;
+    });
+
+    const saved = await saveCache("some key", "some version", "some file path");
+    expect(saved).toBe(false);
   });
 });

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -16,7 +16,7 @@ import { downloadFile } from "./api/download.js";
  * @param version - The cache version.
  * @param filePath - The path of the file to be restored.
  * @returns A promise that resolves to a boolean value indicating whether the
- * file was successfully restored.
+ * file was restored successfully.
  */
 export async function restoreCache(
   key: string,
@@ -35,24 +35,24 @@ export async function restoreCache(
  * @param key - The cache key.
  * @param version - The cache version.
  * @param filePath - The path of the file to be saved.
- * @returns A promise that resolves when the file has been successfully saved.
+ * @returns A promise that resolves to a boolean value indicating whether the
+ * file was saved successfully.
  */
 export async function saveCache(
   key: string,
   version: string,
   filePath: string,
-): Promise<void> {
+): Promise<boolean> {
   const fileSize = fs.statSync(filePath).size;
   const cacheId = await reserveCache(key, version, fileSize);
-  if (cacheId !== null) {
-    const file = fs.createReadStream(filePath, {
-      fd: fs.openSync(filePath, "r"),
-      autoClose: false,
-      start: 0,
-      end: fileSize,
-    });
-    await uploadCache(cacheId, file, fileSize);
-
-    await commitCache(cacheId, fileSize);
-  }
+  if (cacheId === null) return false;
+  const file = fs.createReadStream(filePath, {
+    fd: fs.openSync(filePath, "r"),
+    autoClose: false,
+    start: 0,
+    end: fileSize,
+  });
+  await uploadCache(cacheId, file, fileSize);
+  await commitCache(cacheId, fileSize);
+  return true;
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -44,14 +44,15 @@ export async function saveCache(
 ): Promise<void> {
   const fileSize = fs.statSync(filePath).size;
   const cacheId = await reserveCache(key, version, fileSize);
+  if (cacheId !== null) {
+    const file = fs.createReadStream(filePath, {
+      fd: fs.openSync(filePath, "r"),
+      autoClose: false,
+      start: 0,
+      end: fileSize,
+    });
+    await uploadCache(cacheId, file, fileSize);
 
-  const file = fs.createReadStream(filePath, {
-    fd: fs.openSync(filePath, "r"),
-    autoClose: false,
-    start: 0,
-    end: fileSize,
-  });
-  await uploadCache(cacheId, file, fileSize);
-
-  await commitCache(cacheId, fileSize);
+    await commitCache(cacheId, fileSize);
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,11 @@ try {
   }
 
   logInfo("Cache does not exist, saving...");
-  await saveCache(key, version, filePath);
-  logInfo("Cache successfully saved");
+  if (await saveCache(key, version, filePath)) {
+    logInfo("Cache successfully saved");
+  } else {
+    logInfo("Cache exists");
+  }
 } catch (err) {
   logError(err);
   process.exit(1);


### PR DESCRIPTION
This pull request resolves #63 by modifying the `saveCache` function to return a boolean value indicating whether the cache was saved successfully. It also modifies the `reserveCache` function to return null if the cache is already reserved and updates the tests accordingly.