### PR TITLE
Add Function to Compress and Extract Files

### DIFF
--- a/src/archive.test.ts
+++ b/src/archive.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { compressFiles, extractFiles } from "./archive.js";
+
+describe("compress and extract files", () => {
+  let tempDir = "";
+  beforeAll(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "temp-"));
+  });
+
+  let archivePath = "";
+  it("should compress files to an arhive", async () => {
+    await fs.access(tempDir);
+    await Promise.all([
+      fs.writeFile(path.join(tempDir, "a-file"), "a content"),
+      fs.writeFile(path.join(tempDir, "another-file"), "another content"),
+      (async () => {
+        await fs.mkdir(path.join(tempDir, "a-dir"));
+        await fs.writeFile(path.join(tempDir, "a-dir", "a-file"), "a content");
+      })(),
+    ]);
+
+    archivePath = path.join(tempDir, "archive.tar");
+    await compressFiles(archivePath, [
+      path.join(tempDir, "a-file"),
+      path.join(tempDir, "another-file"),
+      path.join(tempDir, "a-dir", "a-file"),
+    ]);
+
+    await fs.access(archivePath);
+  });
+
+  it("should extract files from an archive", async () => {
+    await fs.access(archivePath);
+    await Promise.all([
+      fs.rm(path.join(tempDir, "a-file")),
+      fs.rm(path.join(tempDir, "a-file")),
+      fs.rm(path.join(tempDir, "a-dir"), { recursive: true }),
+    ]);
+
+    await extractFiles(archivePath);
+
+    await Promise.all([
+      expect(
+        fs.readFile(path.join(tempDir, "a-file"), { encoding: "utf-8" }),
+      ).resolves.toBe("a content"),
+      expect(
+        fs.readFile(path.join(tempDir, "another-file"), { encoding: "utf-8" }),
+      ).resolves.toBe("another content"),
+      expect(
+        fs.readFile(path.join(tempDir, "a-dir", "a-file"), {
+          encoding: "utf-8",
+        }),
+      ).resolves.toBe("a content"),
+    ]);
+  });
+
+  afterAll(async () => {
+    await fs.rm(tempDir, { recursive: true });
+  });
+});

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -1,0 +1,28 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFilePromise = promisify(execFile);
+
+/**
+ * Compresses files into an archive using Tar.
+ *
+ * @param archivePath - The output path for the archive.
+ * @param filePaths - The paths of the files to be compressed.
+ * @returns A promise that resolves when the files have been successfully compressed.
+ */
+export async function compressFiles(
+  archivePath: string,
+  filePaths: string[],
+): Promise<void> {
+  await execFilePromise("tar", ["-cf", archivePath, "-P", ...filePaths]);
+}
+
+/**
+ * Extracts files from an archive using Tar.
+ *
+ * @param archivePath - The path to the archive.
+ * @returns A promise that resolves when the files have been successfully extracted.
+ */
+export async function extractFiles(archivePath: string): Promise<void> {
+  await execFilePromise("tar", ["-xf", archivePath, "-P"]);
+}


### PR DESCRIPTION
This pull request resolves #68 by adding the `compressFiles` and `extractFiles` functions, along with their tests. These functions are used to compress files into an archive and extract files from an archive using [Tar](https://en.wikipedia.org/wiki/Tar_(computing)).