### PR TITLE
Simplify Read Stream Creation in Save Cache Function

### DIFF
--- a/dist/post.mjs
+++ b/dist/post.mjs
@@ -212,12 +212,7 @@ async function saveCache(key, version, filePaths) {
     const cacheId = await reserveCache(key, version, fileSize);
     if (cacheId === null)
         return false;
-    const file = fs.createReadStream("cache.tar", {
-        fd: fs.openSync("cache.tar", "r"),
-        autoClose: false,
-        start: 0,
-        end: fileSize,
-    });
+    const file = fs.createReadStream("cache.tar", { start: 0, end: fileSize });
     await uploadCache(cacheId, file, fileSize);
     await commitCache(cacheId, fileSize);
     return true;

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -1,7 +1,6 @@
 import { jest } from "@jest/globals";
 
 const fs = {
-  openSync: jest.fn(),
   createReadStream: jest.fn(),
   statSync: jest.fn(),
 };
@@ -94,20 +93,9 @@ describe("save files to caches", () => {
       return 32;
     });
 
-    fs.openSync.mockImplementation((path, flags) => {
-      expect(path).toBe("cache.tar");
-      expect(flags).toBe("r");
-      return "some file";
-    });
-
     fs.createReadStream.mockImplementation((path, option) => {
       expect(path).toBe("cache.tar");
-      expect(option).toEqual({
-        fd: "some file",
-        autoClose: false,
-        start: 0,
-        end: 1024,
-      });
+      expect(option).toEqual({ start: 0, end: 1024 });
       return "some file stream";
     });
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -47,12 +47,7 @@ export async function saveCache(
   const fileSize = fs.statSync("cache.tar").size;
   const cacheId = await reserveCache(key, version, fileSize);
   if (cacheId === null) return false;
-  const file = fs.createReadStream("cache.tar", {
-    fd: fs.openSync("cache.tar", "r"),
-    autoClose: false,
-    start: 0,
-    end: fileSize,
-  });
+  const file = fs.createReadStream("cache.tar", { start: 0, end: fileSize });
   await uploadCache(cacheId, file, fileSize);
   await commitCache(cacheId, fileSize);
   return true;


### PR DESCRIPTION
This pull request resolves #70 by simplifying the read stream creation in the `saveCache` function.