### PR TITLE
Audit Imported Node.js Promises Module

### DIFF
--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import 'node:path';
 import https from 'node:https';
-import stream from 'node:stream/promises';
+import streamPromises from 'node:stream/promises';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
@@ -141,7 +141,7 @@ async function downloadFile(url, savePath) {
     const req = https.request(url);
     const res = await sendRequest(req);
     const file = fs.createWriteStream(savePath);
-    await stream.pipeline(res, file);
+    await streamPromises.pipeline(res, file);
 }
 
 const execFilePromise = promisify(execFile);

--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import 'node:path';
+import 'node:fs/promises';
 import https from 'node:https';
 import streamPromises from 'node:stream/promises';
 import { execFile } from 'node:child_process';

--- a/src/api/download.test.ts
+++ b/src/api/download.test.ts
@@ -6,8 +6,10 @@ jest.unstable_mockModule("node:fs", () => ({ default: fs }));
 const https = { request: jest.fn() };
 jest.unstable_mockModule("node:https", () => ({ default: https }));
 
-const stream = { pipeline: jest.fn() };
-jest.unstable_mockModule("node:stream/promises", () => ({ default: stream }));
+const streamPromises = { pipeline: jest.fn() };
+jest.unstable_mockModule("node:stream/promises", () => ({
+  default: streamPromises,
+}));
 
 const sendRequest = jest.fn();
 jest.unstable_mockModule("./https.js", () => ({ sendRequest }));
@@ -31,7 +33,7 @@ describe("download files", () => {
       return "some file stream";
     });
 
-    stream.pipeline.mockImplementation(async (source, destination) => {
+    streamPromises.pipeline.mockImplementation(async (source, destination) => {
       expect(source).toBe("some response");
       expect(destination).toBe("some file stream");
     });

--- a/src/api/download.ts
+++ b/src/api/download.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import https from "node:https";
-import stream from "node:stream/promises";
+import streamPromises from "node:stream/promises";
 import { sendRequest } from "./https.js";
 
 /**
@@ -18,5 +18,5 @@ export async function downloadFile(
   const res = await sendRequest(req);
 
   const file = fs.createWriteStream(savePath);
-  await stream.pipeline(res, file);
+  await streamPromises.pipeline(res, file);
 }

--- a/src/archive.test.ts
+++ b/src/archive.test.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs/promises";
+import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { compressFiles, extractFiles } from "./archive.js";
@@ -6,18 +6,24 @@ import { compressFiles, extractFiles } from "./archive.js";
 describe("compress and extract files", () => {
   let tempDir = "";
   beforeAll(async () => {
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "temp-"));
+    tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "temp-"));
   });
 
   let archivePath = "";
   it("should compress files to an arhive", async () => {
-    await fs.access(tempDir);
+    await fsPromises.access(tempDir);
     await Promise.all([
-      fs.writeFile(path.join(tempDir, "a-file"), "a content"),
-      fs.writeFile(path.join(tempDir, "another-file"), "another content"),
+      fsPromises.writeFile(path.join(tempDir, "a-file"), "a content"),
+      fsPromises.writeFile(
+        path.join(tempDir, "another-file"),
+        "another content",
+      ),
       (async () => {
-        await fs.mkdir(path.join(tempDir, "a-dir"));
-        await fs.writeFile(path.join(tempDir, "a-dir", "a-file"), "a content");
+        await fsPromises.mkdir(path.join(tempDir, "a-dir"));
+        await fsPromises.writeFile(
+          path.join(tempDir, "a-dir", "a-file"),
+          "a content",
+        );
       })(),
     ]);
 
@@ -28,28 +34,32 @@ describe("compress and extract files", () => {
       path.join(tempDir, "a-dir", "a-file"),
     ]);
 
-    await fs.access(archivePath);
+    await fsPromises.access(archivePath);
   });
 
   it("should extract files from an archive", async () => {
-    await fs.access(archivePath);
+    await fsPromises.access(archivePath);
     await Promise.all([
-      fs.rm(path.join(tempDir, "a-file")),
-      fs.rm(path.join(tempDir, "a-file")),
-      fs.rm(path.join(tempDir, "a-dir"), { recursive: true }),
+      fsPromises.rm(path.join(tempDir, "a-file")),
+      fsPromises.rm(path.join(tempDir, "a-file")),
+      fsPromises.rm(path.join(tempDir, "a-dir"), { recursive: true }),
     ]);
 
     await extractFiles(archivePath);
 
     await Promise.all([
       expect(
-        fs.readFile(path.join(tempDir, "a-file"), { encoding: "utf-8" }),
+        fsPromises.readFile(path.join(tempDir, "a-file"), {
+          encoding: "utf-8",
+        }),
       ).resolves.toBe("a content"),
       expect(
-        fs.readFile(path.join(tempDir, "another-file"), { encoding: "utf-8" }),
+        fsPromises.readFile(path.join(tempDir, "another-file"), {
+          encoding: "utf-8",
+        }),
       ).resolves.toBe("another content"),
       expect(
-        fs.readFile(path.join(tempDir, "a-dir", "a-file"), {
+        fsPromises.readFile(path.join(tempDir, "a-dir", "a-file"), {
           encoding: "utf-8",
         }),
       ).resolves.toBe("a content"),
@@ -57,6 +67,6 @@ describe("compress and extract files", () => {
   });
 
   afterAll(async () => {
-    await fs.rm(tempDir, { recursive: true });
+    await fsPromises.rm(tempDir, { recursive: true });
   });
 });

--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -1,10 +1,10 @@
 import { jest } from "@jest/globals";
 
-const fs = {
-  createReadStream: jest.fn(),
-  statSync: jest.fn(),
-};
+const fs = { createReadStream: jest.fn() };
 jest.unstable_mockModule("node:fs", () => ({ default: fs }));
+
+const fsPromises = { stat: jest.fn() };
+jest.unstable_mockModule("node:fs/promises", () => ({ default: fsPromises }));
 
 const commitCache = jest.fn();
 const getCache = jest.fn();
@@ -81,7 +81,7 @@ describe("save files to caches", () => {
       expect(filePaths).toEqual(["some file path", "some other file path"]);
     });
 
-    fs.statSync.mockImplementation((path) => {
+    fsPromises.stat.mockImplementation(async (path) => {
       expect(path).toBe("cache.tar");
       return { size: 1024 };
     });
@@ -125,7 +125,7 @@ describe("save files to caches", () => {
       expect(filePaths).toEqual(["some file path", "some other file path"]);
     });
 
-    fs.statSync.mockImplementation((path) => {
+    fsPromises.stat.mockImplementation(async (path) => {
       expect(path).toBe("cache.tar");
       return { size: 1024 };
     });


### PR DESCRIPTION
This pull request resolves #74 by introducing the following changes:
- Prefixing imported promises versions of Node.js built-in modules.
- Replacing `fs.statSync` with `fsPromises.stat`.