### PR TITLE
Upload Cache in Chunk

### DIFF
--- a/src/api/cache.test.ts
+++ b/src/api/cache.test.ts
@@ -6,7 +6,12 @@ interface Response {
 }
 
 let files: Record<string, string | undefined> = {};
-let requestHandler: (req: any, data: string) => Response;
+let requestHandler: (
+  req: any,
+  data: string,
+  start: number,
+  end: number,
+) => Response;
 
 beforeEach(() => {
   files = {};
@@ -20,7 +25,7 @@ jest.unstable_mockModule("node:fs", () => ({
     createReadStream: (path: string, options: any) => {
       const content = files[path];
       if (content === undefined) throw new Error(`path ${path} does not exist`);
-      return () => content.substring(options.start, options.end);
+      return () => content.substring(options.start, options.end + 1);
     },
   },
 }));
@@ -39,10 +44,12 @@ jest.unstable_mockModule("./https.js", () => ({
     return res.data;
   },
   sendJsonRequest: async (req: any, data: any) => {
-    return requestHandler(req, JSON.stringify(data));
+    const jsonData = JSON.stringify(data);
+    return requestHandler(req, jsonData, 0, jsonData.length - 1);
   },
-  sendRequest: async (req: any, data: string) => {
-    return requestHandler(req, data);
+  sendRequest: async (req: any, data?: string) => {
+    if (data === undefined) data = "";
+    return requestHandler(req, data, 0, data.length - 1);
   },
   sendStreamRequest: async (
     req: any,
@@ -50,7 +57,7 @@ jest.unstable_mockModule("./https.js", () => ({
     start: number,
     end: number,
   ) => {
-    return requestHandler(req, bin().substring(start, end));
+    return requestHandler(req, bin(), start, end);
   },
 }));
 
@@ -63,7 +70,7 @@ describe("retrieve caches", () => {
         resourcePath: "cache?keys=a-key&version=a-version",
         method: "GET",
       });
-      expect(data).toBeUndefined();
+      expect(data).toBe("");
       return { statusCode: 200, data: JSON.stringify("a cache") };
     };
 
@@ -134,28 +141,37 @@ describe("upload files to caches", () => {
   it("should upload a file to a cache", async () => {
     const { uploadCache } = await import("./cache.js");
 
-    files["a-file"] = "data";
+    files["a-file"] = "lorem ipsum dolor sit amet";
+    let uploadedData = "";
 
-    requestHandler = (req, data) => {
+    requestHandler = (req, data, start, end) => {
       expect(req).toEqual({
         resourcePath: "caches/32",
         method: "PATCH",
       });
-      expect(data).toBe("data");
+
+      uploadedData =
+        uploadedData.substring(0, start) +
+        data +
+        uploadedData.substring(end + 1, uploadedData.length);
+
       return { statusCode: 204, data: "" };
     };
 
-    await uploadCache(32, "a-file", 4);
+    await uploadCache(32, "a-file", files["a-file"].length, {
+      maxChunkSize: 8,
+    });
+    expect(uploadedData).toBe("lorem ipsum dolor sit amet");
   });
 
   it("should fail to upload a file to a cache", async () => {
     const { uploadCache } = await import("./cache.js");
 
-    files["a-file"] = "data";
+    files["a-file"] = "lorem ipsum dolor sit amet";
 
     requestHandler = () => ({ statusCode: 500, data: "an error" });
 
-    const prom = uploadCache(32, "a-file", 4);
+    const prom = uploadCache(32, "a-file", files["a-file"].length);
     await expect(prom).rejects.toThrow("an error");
   });
 });

--- a/src/api/cache.ts
+++ b/src/api/cache.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 import {
   createRequest,
   handleErrorResponse,
@@ -7,8 +9,6 @@ import {
   sendRequest,
   sendStreamRequest,
 } from "./https.js";
-
-import type stream from "node:stream";
 
 interface Cache {
   scope: string;
@@ -85,17 +85,18 @@ export async function reserveCache(
  * Uploads a file to a cache with the specified ID.
  *
  * @param id - The cache ID.
- * @param file - The readable stream of the file to upload.
+ * @param file - The path of the file to upload.
  * @param fileSize - The size of the file to upload, in bytes.
  * @returns A promise that resolves with nothing.
  */
 export async function uploadCache(
   id: number,
-  file: stream.Readable,
+  filePath: string,
   fileSize: number,
 ): Promise<void> {
+  const bin = fs.createReadStream(filePath, { start: 0, end: fileSize });
   const req = createRequest(`caches/${id}`, { method: "PATCH" });
-  const res = await sendStreamRequest(req, file, 0, fileSize);
+  const res = await sendStreamRequest(req, bin, 0, fileSize);
   if (res.statusCode !== 204) {
     throw await handleErrorResponse(res);
   }

--- a/src/api/cache.ts
+++ b/src/api/cache.ts
@@ -82,25 +82,40 @@ export async function reserveCache(
 }
 
 /**
- * Uploads a file to a cache with the specified ID.
+ * Uploads a file to the cache with the specified ID.
  *
  * @param id - The cache ID.
- * @param file - The path of the file to upload.
+ * @param filePath - The path of the file to upload.
  * @param fileSize - The size of the file to upload, in bytes.
- * @returns A promise that resolves with nothing.
+ * @returns A promise that resolves to nothing.
  */
 export async function uploadCache(
   id: number,
   filePath: string,
   fileSize: number,
+  options?: { maxChunkSize?: number },
 ): Promise<void> {
-  const bin = fs.createReadStream(filePath, { start: 0, end: fileSize });
-  const req = createRequest(`caches/${id}`, { method: "PATCH" });
-  const res = await sendStreamRequest(req, bin, 0, fileSize);
-  if (res.statusCode !== 204) {
-    throw await handleErrorResponse(res);
+  const { maxChunkSize } = {
+    maxChunkSize: 32 * 1024 * 1024,
+    ...options,
+  };
+
+  for (let start = 0; start < fileSize; start += maxChunkSize) {
+    const end = Math.min(start + maxChunkSize - 1, fileSize);
+    const bin = fs.createReadStream(filePath, { start, end });
+
+    const req = createRequest(`caches/${id}`, { method: "PATCH" });
+    const res = await sendStreamRequest(req, bin, start, end);
+
+    switch (res.statusCode) {
+      case 204:
+        await handleResponse(res);
+        break;
+
+      default:
+        throw await handleErrorResponse(res);
+    }
   }
-  await handleResponse(res);
 }
 
 /**

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -56,20 +55,16 @@ export async function saveCache(
   const archivePath = path.join(tempDir, "cache.tar");
 
   await compressFiles(archivePath, filePaths);
-  const fileStat = await fsPromises.stat(archivePath);
+  const archiveStat = await fsPromises.stat(archivePath);
 
-  const cacheId = await reserveCache(key, version, fileStat.size);
+  const cacheId = await reserveCache(key, version, archiveStat.size);
   if (cacheId === null) {
     fsPromises.rm(tempDir, { recursive: true });
     return false;
   }
 
-  const file = fs.createReadStream(archivePath, {
-    start: 0,
-    end: fileStat.size,
-  });
-  await uploadCache(cacheId, file, fileStat.size);
-  await commitCache(cacheId, fileStat.size);
+  await uploadCache(cacheId, archivePath, archiveStat.size);
+  await commitCache(cacheId, archiveStat.size);
 
   fsPromises.rm(tempDir, { recursive: true });
   return true;


### PR DESCRIPTION
This pull request resolves #80 by modifying the `uploadCache` function to upload the cache in chunks using the specified file path. It also updates the tests' simulations accordingly.