### PR TITLE
Compress Files Using Zstandard

### DIFF
--- a/src/archive.ts
+++ b/src/archive.ts
@@ -4,7 +4,7 @@ import { promisify } from "node:util";
 const execFilePromise = promisify(execFile);
 
 /**
- * Compresses files into an archive using Tar.
+ * Compresses files into an archive using Tar and Zstandard.
  *
  * @param archivePath - The output path for the archive.
  * @param filePaths - The paths of the files to be compressed.
@@ -14,15 +14,28 @@ export async function compressFiles(
   archivePath: string,
   filePaths: string[],
 ): Promise<void> {
-  await execFilePromise("tar", ["-cf", archivePath, "-P", ...filePaths]);
+  await execFilePromise("tar", [
+    "--use-compress-program",
+    "zstd -T0",
+    "-cf",
+    archivePath,
+    "-P",
+    ...filePaths,
+  ]);
 }
 
 /**
- * Extracts files from an archive using Tar.
+ * Extracts files from an archive using Tar and Zstandard.
  *
  * @param archivePath - The path to the archive.
  * @returns A promise that resolves when the files have been successfully extracted.
  */
 export async function extractFiles(archivePath: string): Promise<void> {
-  await execFilePromise("tar", ["-xf", archivePath, "-P"]);
+  await execFilePromise("tar", [
+    "--use-compress-program",
+    "zstd -d -T0",
+    "-xf",
+    archivePath,
+    "-P",
+  ]);
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -28,7 +28,7 @@ export async function restoreCache(
   if (cache === null) return false;
 
   const tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "temp-"));
-  const archivePath = path.join(tempDir, "cache.tar");
+  const archivePath = path.join(tempDir, "cache.tar.zst");
 
   await downloadFile(cache.archiveLocation, archivePath);
   await extractFiles(archivePath);
@@ -52,7 +52,7 @@ export async function saveCache(
   filePaths: string[],
 ): Promise<boolean> {
   const tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "temp-"));
-  const archivePath = path.join(tempDir, "cache.tar");
+  const archivePath = path.join(tempDir, "cache.tar.zst");
 
   await compressFiles(archivePath, filePaths);
   const archiveStat = await fsPromises.stat(archivePath);


### PR DESCRIPTION
This pull request resolves #89 by modifying the `restoreCache` and `saveCache` functions to compress files using [Zstandard](https://facebook.github.io/zstd/).