### PR TITLE
Upload Cache Concurrently

### DIFF
--- a/dist/post.mjs
+++ b/dist/post.mjs
@@ -163,7 +163,7 @@ async function reserveCache(key, version, size) {
  */
 async function uploadCache(id, filePath, fileSize, options) {
     const { maxChunkSize } = {
-        maxChunkSize: 32 * 1024 * 1024,
+        maxChunkSize: 4 * 1024 * 1024,
         ...options,
     };
     const proms = [];

--- a/dist/post.mjs
+++ b/dist/post.mjs
@@ -166,19 +166,23 @@ async function uploadCache(id, filePath, fileSize, options) {
         maxChunkSize: 32 * 1024 * 1024,
         ...options,
     };
+    const proms = [];
     for (let start = 0; start < fileSize; start += maxChunkSize) {
-        const end = Math.min(start + maxChunkSize - 1, fileSize);
-        const bin = fs.createReadStream(filePath, { start, end });
-        const req = createRequest(`caches/${id}`, { method: "PATCH" });
-        const res = await sendStreamRequest(req, bin, start, end);
-        switch (res.statusCode) {
-            case 204:
-                await handleResponse(res);
-                break;
-            default:
-                throw await handleErrorResponse(res);
-        }
+        proms.push((async () => {
+            const end = Math.min(start + maxChunkSize - 1, fileSize);
+            const bin = fs.createReadStream(filePath, { start, end });
+            const req = createRequest(`caches/${id}`, { method: "PATCH" });
+            const res = await sendStreamRequest(req, bin, start, end);
+            switch (res.statusCode) {
+                case 204:
+                    await handleResponse(res);
+                    break;
+                default:
+                    throw await handleErrorResponse(res);
+            }
+        })());
     }
+    await Promise.all(proms);
 }
 /**
  * Commits a cache with the specified ID.

--- a/src/api/cache.ts
+++ b/src/api/cache.ts
@@ -100,22 +100,29 @@ export async function uploadCache(
     ...options,
   };
 
+  const proms: Promise<void>[] = [];
   for (let start = 0; start < fileSize; start += maxChunkSize) {
-    const end = Math.min(start + maxChunkSize - 1, fileSize);
-    const bin = fs.createReadStream(filePath, { start, end });
+    proms.push(
+      (async () => {
+        const end = Math.min(start + maxChunkSize - 1, fileSize);
+        const bin = fs.createReadStream(filePath, { start, end });
 
-    const req = createRequest(`caches/${id}`, { method: "PATCH" });
-    const res = await sendStreamRequest(req, bin, start, end);
+        const req = createRequest(`caches/${id}`, { method: "PATCH" });
+        const res = await sendStreamRequest(req, bin, start, end);
 
-    switch (res.statusCode) {
-      case 204:
-        await handleResponse(res);
-        break;
+        switch (res.statusCode) {
+          case 204:
+            await handleResponse(res);
+            break;
 
-      default:
-        throw await handleErrorResponse(res);
-    }
+          default:
+            throw await handleErrorResponse(res);
+        }
+      })(),
+    );
   }
+
+  await Promise.all(proms);
 }
 
 /**

--- a/src/api/cache.ts
+++ b/src/api/cache.ts
@@ -96,7 +96,7 @@ export async function uploadCache(
   options?: { maxChunkSize?: number },
 ): Promise<void> {
   const { maxChunkSize } = {
-    maxChunkSize: 32 * 1024 * 1024,
+    maxChunkSize: 4 * 1024 * 1024,
     ...options,
   };
 


### PR DESCRIPTION
This pull request resolves #91 by modifying the `uploadCache` function to upload the cache concurrently. It also decreases the default maximum cache size when uploading to 4 MB.