### PR TITLE
Fix Save Cache Stuck Using Large Files on Windows

### DIFF
--- a/dist/post.mjs
+++ b/dist/post.mjs
@@ -4,7 +4,7 @@ import path from 'node:path';
 import fsPromises from 'node:fs/promises';
 import https from 'node:https';
 import 'node:stream/promises';
-import { execFile } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 
 /**
@@ -197,23 +197,45 @@ async function commitCache(id, size) {
     await handleResponse(res);
 }
 
-const execFilePromise = promisify(execFile);
+promisify(execFile);
+/**
+ * Handles a child process asynchronously.
+ *
+ * @param proc - The child process to handle.
+ * @returns A promise that resolves when the child process exits successfully,
+ * or rejects if the process fails.
+ */
+async function handleProcess(proc) {
+    return new Promise((resolve, reject) => {
+        const chunks = [];
+        proc.stderr?.on("data", (chunk) => chunks.push(chunk));
+        proc.on("error", reject);
+        proc.on("close", (code) => {
+            if (code === 0) {
+                resolve(undefined);
+            }
+            else {
+                reject(new Error([
+                    `Process failed: ${proc.spawnargs.join(" ")}`,
+                    Buffer.concat(chunks).toString(),
+                ].join("\n")));
+            }
+        });
+    });
+}
 /**
  * Compresses files into an archive using Tar and Zstandard.
  *
- * @param archivePath - The output path for the archive.
+ * @param archivePath - The output path for the compressed archive.
  * @param filePaths - The paths of the files to be compressed.
- * @returns A promise that resolves when the files have been successfully compressed.
+ * @returns A promise that resolves when the files have been successfully
+ * compressed and the archive is created.
  */
 async function compressFiles(archivePath, filePaths) {
-    await execFilePromise("tar", [
-        "--use-compress-program",
-        "zstd -T0",
-        "-cf",
-        archivePath,
-        "-P",
-        ...filePaths,
-    ]);
+    const tar = spawn("tar", ["-cf", "-", "-P", ...filePaths]);
+    const zstd = spawn("zstd", ["-T0", "-o", archivePath]);
+    tar.stdout.pipe(zstd.stdin);
+    await Promise.all([handleProcess(tar), handleProcess(zstd)]);
 }
 
 /**

--- a/dist/post.mjs
+++ b/dist/post.mjs
@@ -4,8 +4,7 @@ import path from 'node:path';
 import fsPromises from 'node:fs/promises';
 import https from 'node:https';
 import 'node:stream/promises';
-import { execFile, spawn } from 'node:child_process';
-import { promisify } from 'node:util';
+import { spawn } from 'node:child_process';
 
 /**
  * Retrieves the value of a GitHub Actions input.
@@ -197,7 +196,6 @@ async function commitCache(id, size) {
     await handleResponse(res);
 }
 
-promisify(execFile);
 /**
  * Handles a child process asynchronously.
  *

--- a/src/archive.test.ts
+++ b/src/archive.test.ts
@@ -1,7 +1,20 @@
+import { spawn } from "node:child_process";
 import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { compressFiles, extractFiles } from "./archive.js";
+import { compressFiles, extractFiles, handleProcess } from "./archive.js";
+
+describe("handle processes", () => {
+  it("should handle a successful process", async () => {
+    const proc = spawn("node", ["--version"]);
+    await handleProcess(proc);
+  });
+
+  it("should handle a failing process", async () => {
+    const proc = spawn("node", ["--invalid"]);
+    await expect(handleProcess(proc)).rejects.toThrow(/bad option: --invalid/);
+  });
+});
 
 describe("compress and extract files", () => {
   let tempPath = "";


### PR DESCRIPTION
This pull request resolves #95 by modifying the `compressFiles` and `extractFiles` functions to create and extract a compressed archive by piping the inputs and outputs between the Tar and Zstandard programs, preventing issues with large files getting stuck on Windows.