### PR TITLE
Fix Save Cache Function Does Not Await Temporary Directory Removal

### DIFF
--- a/dist/post.mjs
+++ b/dist/post.mjs
@@ -232,12 +232,12 @@ async function saveCache(key, version, filePaths) {
     const archiveStat = await fsPromises.stat(archivePath);
     const cacheId = await reserveCache(key, version, archiveStat.size);
     if (cacheId === null) {
-        fsPromises.rm(tempDir, { recursive: true });
+        await fsPromises.rm(tempDir, { recursive: true });
         return false;
     }
     await uploadCache(cacheId, archivePath, archiveStat.size);
     await commitCache(cacheId, archiveStat.size);
-    fsPromises.rm(tempDir, { recursive: true });
+    await fsPromises.rm(tempDir, { recursive: true });
     return true;
 }
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -59,13 +59,13 @@ export async function saveCache(
 
   const cacheId = await reserveCache(key, version, archiveStat.size);
   if (cacheId === null) {
-    fsPromises.rm(tempDir, { recursive: true });
+    await fsPromises.rm(tempDir, { recursive: true });
     return false;
   }
 
   await uploadCache(cacheId, archivePath, archiveStat.size);
   await commitCache(cacheId, archiveStat.size);
 
-  fsPromises.rm(tempDir, { recursive: true });
+  await fsPromises.rm(tempDir, { recursive: true });
   return true;
 }


### PR DESCRIPTION
This pull request fixes a possible issue in the `saveCache` function where it does not await the removal of the temporary directory. The function should wait for this process to complete before exiting.