### PR TITLE
Fix Download File Not Handling Error Responses

### DIFF
--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -153,16 +153,23 @@ async function getCache(key, version) {
 /**
  * Downloads a file from the specified URL and saves it to the provided path.
  *
- * @param url - The URL of the file to download.
+ * @param url - The URL of the file to be downloaded.
  * @param savePath - The path where the downloaded file will be saved.
  * @returns A promise that resolves when the download is complete.
  */
 async function downloadFile(url, savePath) {
     const req = https.request(url);
     const res = await sendRequest(req);
-    assertResponseContentType(res, "application/octet-stream");
-    const file = fs.createWriteStream(savePath);
-    await streamPromises.pipeline(res, file);
+    switch (res.statusCode) {
+        case 200: {
+            assertResponseContentType(res, "application/octet-stream");
+            const file = fs.createWriteStream(savePath);
+            await streamPromises.pipeline(res, file);
+            break;
+        }
+        default:
+            throw await handleErrorResponse(res);
+    }
 }
 
 /**

--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -116,14 +116,23 @@ async function handleJsonResponse(res) {
  * @returns A promise that resolves to an `Error` object.
  */
 async function handleErrorResponse(res) {
-    const data = await handleResponse(res);
-    if (res.headers["content-type"]?.includes("application/json")) {
-        const { message } = JSON.parse(data);
-        return new Error(`${message} (${res.statusCode})`);
+    let data = await handleResponse(res);
+    const contentType = res.headers["content-type"];
+    if (contentType !== undefined) {
+        if (contentType.includes("application/json")) {
+            const jsonData = JSON.parse(data);
+            if (typeof jsonData === "object" && "message" in jsonData) {
+                data = jsonData["message"];
+            }
+        }
+        else if (contentType.includes("application/xml")) {
+            const matchData = data.match(/<Message>(.*?)<\/Message>/s);
+            if (matchData !== null && matchData.length > 1) {
+                data = matchData[1];
+            }
+        }
     }
-    else {
-        return new Error(`${data} (${res.statusCode})`);
-    }
+    return new Error(`${data} (${res.statusCode})`);
 }
 
 /**

--- a/src/api/download.ts
+++ b/src/api/download.ts
@@ -1,12 +1,16 @@
 import fs from "node:fs";
 import https from "node:https";
 import streamPromises from "node:stream/promises";
-import { assertResponseContentType, sendRequest } from "./https.js";
+import {
+  assertResponseContentType,
+  handleErrorResponse,
+  sendRequest,
+} from "./https.js";
 
 /**
  * Downloads a file from the specified URL and saves it to the provided path.
  *
- * @param url - The URL of the file to download.
+ * @param url - The URL of the file to be downloaded.
  * @param savePath - The path where the downloaded file will be saved.
  * @returns A promise that resolves when the download is complete.
  */
@@ -15,10 +19,17 @@ export async function downloadFile(
   savePath: string,
 ): Promise<void> {
   const req = https.request(url);
-
   const res = await sendRequest(req);
-  assertResponseContentType(res, "application/octet-stream");
 
-  const file = fs.createWriteStream(savePath);
-  await streamPromises.pipeline(res, file);
+  switch (res.statusCode) {
+    case 200: {
+      assertResponseContentType(res, "application/octet-stream");
+      const file = fs.createWriteStream(savePath);
+      await streamPromises.pipeline(res, file);
+      break;
+    }
+
+    default:
+      throw await handleErrorResponse(res);
+  }
 }

--- a/src/api/https.test.ts
+++ b/src/api/https.test.ts
@@ -286,6 +286,18 @@ describe("handle HTTPS responses containing error data", () => {
     await expect(prom).resolves.toEqual(new Error("an error (500)"));
   });
 
+  it("should handle an HTTPS response containing error data in XML", async () => {
+    const { handleErrorResponse } = await import("./https.js");
+
+    const res = new Response(500, { "content-type": "application/xml" });
+    const prom = handleErrorResponse(res as any);
+
+    res.write("<?xml><Message>an error</Message>");
+    res.end();
+
+    await expect(prom).resolves.toEqual(new Error("an error (500)"));
+  });
+
   it("should handle an HTTPS response containing error data in string", async () => {
     const { handleErrorResponse } = await import("./https.js");
 


### PR DESCRIPTION
This pull request resolves #101 by fixing the `downloadFile` function to handle error responses when the status code is not OK. Additionally, it modifies the `handleErrorResponse` function to support handling errors in XML format and updates test simulations to include error response handling scenarios.