### PR TITLE
Handle HTTPS Response Content Type Strictly

### DIFF
--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -154,6 +154,7 @@ async function getCache(key, version) {
 async function downloadFile(url, savePath) {
     const req = https.request(url);
     const res = await sendRequest(req);
+    assertResponseContentType(res, "application/octet-stream");
     const file = fs.createWriteStream(savePath);
     await streamPromises.pipeline(res, file);
 }

--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -71,6 +71,19 @@ async function sendRequest(req, data) {
     });
 }
 /**
+ * Asserts whether the content type of the given HTTP response matches the expected type.
+ *
+ * @param res - The HTTP response.
+ * @param expectedType - The expected content type of the HTTP response.
+ * @throws {Error} Throws an error if the content type does not match the expected type.
+ */
+function assertResponseContentType(res, expectedType) {
+    const actualType = res.headers["content-type"] ?? "undefined";
+    if (!actualType.includes(expectedType)) {
+        throw new Error(`expected content type of the response to be '${expectedType}', but instead got '${actualType}'`);
+    }
+}
+/**
  * Handles an HTTPS response containing raw data.
  *
  * @param res - The HTTPS response object.
@@ -92,6 +105,7 @@ async function handleResponse(res) {
  * @returns A promise that resolves to the parsed JSON data of type T.
  */
 async function handleJsonResponse(res) {
+    assertResponseContentType(res, "application/json");
     const data = await handleResponse(res);
     return JSON.parse(data);
 }

--- a/dist/post.mjs
+++ b/dist/post.mjs
@@ -93,6 +93,19 @@ async function sendStreamRequest(req, bin, start, end) {
     });
 }
 /**
+ * Asserts whether the content type of the given HTTP response matches the expected type.
+ *
+ * @param res - The HTTP response.
+ * @param expectedType - The expected content type of the HTTP response.
+ * @throws {Error} Throws an error if the content type does not match the expected type.
+ */
+function assertResponseContentType(res, expectedType) {
+    const actualType = res.headers["content-type"] ?? "undefined";
+    if (!actualType.includes(expectedType)) {
+        throw new Error(`expected content type of the response to be '${expectedType}', but instead got '${actualType}'`);
+    }
+}
+/**
  * Handles an HTTPS response containing raw data.
  *
  * @param res - The HTTPS response object.
@@ -114,6 +127,7 @@ async function handleResponse(res) {
  * @returns A promise that resolves to the parsed JSON data of type T.
  */
 async function handleJsonResponse(res) {
+    assertResponseContentType(res, "application/json");
     const data = await handleResponse(res);
     return JSON.parse(data);
 }

--- a/src/api/download.ts
+++ b/src/api/download.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import https from "node:https";
 import streamPromises from "node:stream/promises";
-import { sendRequest } from "./https.js";
+import { assertResponseContentType, sendRequest } from "./https.js";
 
 /**
  * Downloads a file from the specified URL and saves it to the provided path.
@@ -15,7 +15,9 @@ export async function downloadFile(
   savePath: string,
 ): Promise<void> {
   const req = https.request(url);
+
   const res = await sendRequest(req);
+  assertResponseContentType(res, "application/octet-stream");
 
   const file = fs.createWriteStream(savePath);
   await streamPromises.pipeline(res, file);

--- a/src/api/https.test.ts
+++ b/src/api/https.test.ts
@@ -263,7 +263,7 @@ describe("handle HTTPS responses containing JSON data", () => {
   it("should handle an HTTPS response", async () => {
     const { handleJsonResponse } = await import("./https.js");
 
-    const res = new Response();
+    const res = new Response(200, { "content-type": "application/json" });
     const prom = handleJsonResponse(res as any);
 
     res.write(JSON.stringify({ message: "a message" }));
@@ -277,7 +277,7 @@ describe("handle HTTPS responses containing error data", () => {
   it("should handle an HTTPS response", async () => {
     const { handleErrorResponse } = await import("./https.js");
 
-    const res = new Response(500);
+    const res = new Response(500, { "content-type": "application/json" });
     const prom = handleErrorResponse(res as any);
 
     res.write(JSON.stringify({ message: "an error" }));

--- a/src/api/https.ts
+++ b/src/api/https.ts
@@ -90,6 +90,25 @@ export async function sendStreamRequest(
 }
 
 /**
+ * Asserts whether the content type of the given HTTP response matches the expected type.
+ *
+ * @param res - The HTTP response.
+ * @param expectedType - The expected content type of the HTTP response.
+ * @throws {Error} Throws an error if the content type does not match the expected type.
+ */
+export function assertResponseContentType(
+  res: http.IncomingMessage,
+  expectedType: string,
+): void {
+  const actualType = res.headers["content-type"] ?? "undefined";
+  if (!actualType.includes(expectedType)) {
+    throw new Error(
+      `expected content type of the response to be '${expectedType}', but instead got '${actualType}'`,
+    );
+  }
+}
+
+/**
  * Handles an HTTPS response containing raw data.
  *
  * @param res - The HTTPS response object.

--- a/src/api/https.ts
+++ b/src/api/https.ts
@@ -135,6 +135,7 @@ export async function handleResponse(
 export async function handleJsonResponse<T>(
   res: http.IncomingMessage,
 ): Promise<T> {
+  assertResponseContentType(res, "application/json");
   const data = await handleResponse(res);
   return JSON.parse(data);
 }


### PR DESCRIPTION
This pull request resolves #103 by modifying the `downloadFile` and `handleJsonResponse` functions to handle HTTPS response content types more strictly by asserting that the content type matches the expected type. Additionally, it introduces a new `assertResponseContentType` function to facilitate the assertion of the HTTPS response content type.