### PR TITLE
Allow Handling HTTPS Response Errors Containing Non-JSON Data

### DIFF
--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -113,11 +113,17 @@ async function handleJsonResponse(res) {
  * Handles an HTTPS response containing error data.
  *
  * @param res - The HTTPS response object.
- * @returns A promise that resolves to an error object.
+ * @returns A promise that resolves to an `Error` object.
  */
 async function handleErrorResponse(res) {
-    const { message } = await handleJsonResponse(res);
-    return new Error(`${message} (${res.statusCode})`);
+    const data = await handleResponse(res);
+    if (res.headers["content-type"]?.includes("application/json")) {
+        const { message } = JSON.parse(data);
+        return new Error(`${message} (${res.statusCode})`);
+    }
+    else {
+        return new Error(`${data} (${res.statusCode})`);
+    }
 }
 
 /**

--- a/dist/post.mjs
+++ b/dist/post.mjs
@@ -135,11 +135,17 @@ async function handleJsonResponse(res) {
  * Handles an HTTPS response containing error data.
  *
  * @param res - The HTTPS response object.
- * @returns A promise that resolves to an error object.
+ * @returns A promise that resolves to an `Error` object.
  */
 async function handleErrorResponse(res) {
-    const { message } = await handleJsonResponse(res);
-    return new Error(`${message} (${res.statusCode})`);
+    const data = await handleResponse(res);
+    if (res.headers["content-type"]?.includes("application/json")) {
+        const { message } = JSON.parse(data);
+        return new Error(`${message} (${res.statusCode})`);
+    }
+    else {
+        return new Error(`${data} (${res.statusCode})`);
+    }
 }
 
 /**

--- a/src/api/https.test.ts
+++ b/src/api/https.test.ts
@@ -274,13 +274,25 @@ describe("handle HTTPS responses containing JSON data", () => {
 });
 
 describe("handle HTTPS responses containing error data", () => {
-  it("should handle an HTTPS response", async () => {
+  it("should handle an HTTPS response containing error data in JSON", async () => {
     const { handleErrorResponse } = await import("./https.js");
 
     const res = new Response(500, { "content-type": "application/json" });
     const prom = handleErrorResponse(res as any);
 
     res.write(JSON.stringify({ message: "an error" }));
+    res.end();
+
+    await expect(prom).resolves.toEqual(new Error("an error (500)"));
+  });
+
+  it("should handle an HTTPS response containing error data in string", async () => {
+    const { handleErrorResponse } = await import("./https.js");
+
+    const res = new Response(500);
+    const prom = handleErrorResponse(res as any);
+
+    res.write("an error");
     res.end();
 
     await expect(prom).resolves.toEqual(new Error("an error (500)"));

--- a/src/api/https.ts
+++ b/src/api/https.ts
@@ -144,11 +144,16 @@ export async function handleJsonResponse<T>(
  * Handles an HTTPS response containing error data.
  *
  * @param res - The HTTPS response object.
- * @returns A promise that resolves to an error object.
+ * @returns A promise that resolves to an `Error` object.
  */
 export async function handleErrorResponse(
   res: http.IncomingMessage,
 ): Promise<Error> {
-  const { message } = await handleJsonResponse<{ message: string }>(res);
-  return new Error(`${message} (${res.statusCode})`);
+  const data = await handleResponse(res);
+  if (res.headers["content-type"]?.includes("application/json")) {
+    const { message } = JSON.parse(data) as { message: string };
+    return new Error(`${message} (${res.statusCode})`);
+  } else {
+    return new Error(`${data} (${res.statusCode})`);
+  }
 }


### PR DESCRIPTION
This pull request resolves #106 by modifying the `handleErrorResponse` function to allow handling HTTPS responses containing non-JSON error data.