### PR TITLE
Get File Size Before Downloading Files

### DIFF
--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -167,7 +167,7 @@ async function getCache(key, version) {
  * @returns A promise that resolves when the download is complete.
  */
 async function downloadFile(url, savePath) {
-    const req = https.request(url);
+    const req = https.request(url, { method: "GET" });
     const res = await sendRequest(req);
     switch (res.statusCode) {
         case 200: {

--- a/src/api/download.test.ts
+++ b/src/api/download.test.ts
@@ -1,5 +1,10 @@
 import { jest } from "@jest/globals";
 
+interface Request {
+  url: string;
+  method: string;
+}
+
 interface Response {
   headers: Record<string, string | undefined>;
   statusCode: number;
@@ -8,6 +13,10 @@ interface Response {
 
 let clouds: Partial<Record<string, string>> = {};
 let files: Partial<Record<string, string>> = {};
+beforeEach(() => {
+  clouds = {};
+  files = {};
+});
 
 jest.unstable_mockModule("node:fs", () => ({
   default: {
@@ -19,7 +28,7 @@ jest.unstable_mockModule("node:fs", () => ({
 
 jest.unstable_mockModule("node:https", () => ({
   default: {
-    request: (url: string) => () => url,
+    request: (url: string, { method }: any): Request => ({ url, method }),
   },
 }));
 
@@ -37,25 +46,52 @@ jest.unstable_mockModule("./https.js", () => ({
     expect(res.headers["content-type"]).toContain(expectedType);
   },
   handleErrorResponse: async (res: Response) => new Error(res.data()),
-  sendRequest: async (req: () => string): Promise<Response> => {
-    const data = clouds[req()];
-    return data !== undefined
-      ? {
-          statusCode: 200,
-          headers: { "content-type": "application/octet-stream" },
-          data: () => data,
-        }
-      : { statusCode: 404, headers: {}, data: () => "not found" };
+  handleResponse: async (res: Response) => res.data(),
+  sendRequest: async (req: Request): Promise<Response> => {
+    const data = clouds[req.url];
+    if (data === undefined) {
+      return { statusCode: 404, headers: {}, data: () => "not found" };
+    }
+
+    if (req.method === "HEAD") {
+      return {
+        statusCode: 200,
+        headers: { "content-length": data.length.toString() },
+        data: () => "",
+      };
+    }
+
+    return {
+      statusCode: 200,
+      headers: {
+        "content-type": "application/octet-stream",
+        "content-length": data.length.toString(),
+      },
+      data: () => data,
+    };
   },
 }));
 
-describe("download files", () => {
-  beforeEach(() => {
-    clouds = {};
-    files = {};
+describe("get the size of files to be downloaded", () => {
+  it("should return the size of a file to be downloaded", async () => {
+    const { getDownloadFileSize } = await import("./download.js");
+
+    clouds["a-url"] = "a content";
+
+    const fileSize = await getDownloadFileSize("a-url");
+    expect(fileSize).toBe(clouds["a-url"].length);
   });
 
-  it("it should download a file", async () => {
+  it("should throw an error for an invalid URL", async () => {
+    const { getDownloadFileSize } = await import("./download.js");
+
+    const prom = getDownloadFileSize("an-invalid-url");
+    await expect(prom).rejects.toThrow("not found");
+  });
+});
+
+describe("download files", () => {
+  it("should download a file successfully", async () => {
     const { downloadFile } = await import("./download.js");
 
     clouds["a-url"] = "a content";
@@ -65,7 +101,7 @@ describe("download files", () => {
     expect(files).toEqual({ "a-file": "a content" });
   });
 
-  it("should fail to download a file", async () => {
+  it("should throw an error for an invalid URL", async () => {
     const { downloadFile } = await import("./download.js");
 
     const prom = downloadFile("an-invalid-url", "a-file");

--- a/src/api/download.ts
+++ b/src/api/download.ts
@@ -41,11 +41,15 @@ export async function downloadFile(
   url: string,
   savePath: string,
 ): Promise<void> {
+  const fileSize = await getDownloadFileSize(url);
+
   const req = https.request(url, { method: "GET" });
+  req.setHeader("range", `bytes=0-${fileSize}`);
+
   const res = await sendRequest(req);
 
   switch (res.statusCode) {
-    case 200: {
+    case 206: {
       assertResponseContentType(res, "application/octet-stream");
       const file = fs.createWriteStream(savePath);
       await streamPromises.pipeline(res, file);

--- a/src/api/download.ts
+++ b/src/api/download.ts
@@ -1,11 +1,34 @@
 import fs from "node:fs";
 import https from "node:https";
 import streamPromises from "node:stream/promises";
+
 import {
   assertResponseContentType,
   handleErrorResponse,
+  handleResponse,
   sendRequest,
 } from "./https.js";
+
+/**
+ * Retrieves the file size of a file to be downloaded from the specified URL.
+ *
+ * @param url - The URL of the file to be downloaded.
+ * @returns A promise that resolves to the size of the file to be downloaded, in bytes.
+ */
+export async function getDownloadFileSize(url: string): Promise<number> {
+  const req = https.request(url, { method: "HEAD" });
+  const res = await sendRequest(req);
+
+  switch (res.statusCode) {
+    case 200: {
+      await handleResponse(res);
+      return Number.parseInt(res.headers["content-length"] as string);
+    }
+
+    default:
+      throw await handleErrorResponse(res);
+  }
+}
 
 /**
  * Downloads a file from the specified URL and saves it to the provided path.
@@ -18,7 +41,7 @@ export async function downloadFile(
   url: string,
   savePath: string,
 ): Promise<void> {
-  const req = https.request(url);
+  const req = https.request(url, { method: "GET" });
   const res = await sendRequest(req);
 
   switch (res.statusCode) {


### PR DESCRIPTION
This pull request resolves #108 by modifying the `getDownloadFileSize` function to retrieve the file size before attempting to download the file. It introduces a new `getDownloadFileSize` function for determining the file size and updates the tests to reflect these changes.