### PR TITLE
Directly Pass Promise Reject to Error Event

### DIFF
--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -66,7 +66,7 @@ function createRequest(resourcePath, options) {
 async function sendRequest(req, data) {
     return new Promise((resolve, reject) => {
         req.on("response", (res) => resolve(res));
-        req.on("error", (err) => reject(err));
+        req.on("error", reject);
         req.end();
     });
 }
@@ -94,7 +94,7 @@ async function handleResponse(res) {
         let data = "";
         res.on("data", (chunk) => (data += chunk.toString()));
         res.on("end", () => resolve(data));
-        res.on("error", (err) => reject(err));
+        res.on("error", reject);
     });
 }
 /**

--- a/dist/post.mjs
+++ b/dist/post.mjs
@@ -57,7 +57,7 @@ function createRequest(resourcePath, options) {
 async function sendRequest(req, data) {
     return new Promise((resolve, reject) => {
         req.on("response", (res) => resolve(res));
-        req.on("error", (err) => reject(err));
+        req.on("error", reject);
         if (data !== undefined)
             req.write(data);
         req.end();
@@ -88,7 +88,7 @@ async function sendStreamRequest(req, bin, start, end) {
         req.setHeader("Content-Type", "application/octet-stream");
         req.setHeader("Content-Range", `bytes ${start}-${end}/*`);
         req.on("response", (res) => resolve(res));
-        req.on("error", (err) => reject(err));
+        req.on("error", reject);
         bin.pipe(req);
     });
 }
@@ -116,7 +116,7 @@ async function handleResponse(res) {
         let data = "";
         res.on("data", (chunk) => (data += chunk.toString()));
         res.on("end", () => resolve(data));
-        res.on("error", (err) => reject(err));
+        res.on("error", reject);
     });
 }
 /**

--- a/src/api/https.test.ts
+++ b/src/api/https.test.ts
@@ -143,17 +143,6 @@ describe("send HTTPS requests containing raw data", () => {
     expect(req.headers).toEqual({});
     expect(req.data).toBe("a message");
   });
-
-  it("should fail to send an HTTPS request", async () => {
-    const { sendRequest } = await import("./https.js");
-
-    const req = new Request();
-    const prom = sendRequest(req as any);
-
-    req.error(new Error("an error"));
-
-    await expect(prom).rejects.toThrow("an error");
-  });
 });
 
 describe("send HTTPS requests containing JSON data", () => {
@@ -190,18 +179,6 @@ describe("send HTTPS requests containing binary streams", () => {
       "Content-Range": "bytes 0-1024/*",
     });
     expect(req.data).toBe("a message");
-  });
-
-  it("should fail to send an HTTPS request", async () => {
-    const { sendStreamRequest } = await import("./https.js");
-
-    const req = new Request();
-    const bin = new Readable();
-    const prom = sendStreamRequest(req as any, bin as any, 0, 1024);
-
-    req.error(new Error("an error"));
-
-    await expect(prom).rejects.toThrow("an error");
   });
 });
 
@@ -245,17 +222,6 @@ describe("handle HTTPS responses containing raw data", () => {
     res.end();
 
     await expect(prom).resolves.toEqual("a message");
-  });
-
-  it("should fail to handle an HTTPS response", async () => {
-    const { handleResponse } = await import("./https.js");
-
-    const res = new Response();
-    const prom = handleResponse(res as any);
-
-    res.error(new Error("an error"));
-
-    await expect(prom).rejects.toThrow("an error");
   });
 });
 

--- a/src/api/https.ts
+++ b/src/api/https.ts
@@ -41,7 +41,7 @@ export async function sendRequest(
 ): Promise<http.IncomingMessage> {
   return new Promise((resolve, reject) => {
     req.on("response", (res) => resolve(res));
-    req.on("error", (err) => reject(err));
+    req.on("error", reject);
 
     if (data !== undefined) req.write(data);
     req.end();
@@ -83,7 +83,7 @@ export async function sendStreamRequest(
     req.setHeader("Content-Range", `bytes ${start}-${end}/*`);
 
     req.on("response", (res) => resolve(res));
-    req.on("error", (err) => reject(err));
+    req.on("error", reject);
 
     bin.pipe(req);
   });
@@ -121,7 +121,7 @@ export async function handleResponse(
     let data = "";
     res.on("data", (chunk) => (data += chunk.toString()));
     res.on("end", () => resolve(data));
-    res.on("error", (err) => reject(err));
+    res.on("error", reject);
   });
 }
 


### PR DESCRIPTION
This pull request resolves #110 by directly passing the promise reject to the error event callback, thereby removing the need to handle error cases separately.