### PR TITLE
Test API Request Using Real Server

### DIFF
--- a/src/api/download.test.ts
+++ b/src/api/download.test.ts
@@ -1,133 +1,99 @@
 import { jest } from "@jest/globals";
+import fsPromises from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
 
-class Request {
-  url: string;
-  method: string;
-  headers: Record<string, string | undefined>;
+jest.unstable_mockModule("node:https", () => ({ default: http }));
 
-  constructor(url: string, method: string) {
-    this.url = url;
-    this.method = method;
-    this.headers = {};
+const serverFiles: Record<string, any | undefined> = {
+  "/a-file": "a content",
+  "/a-corrupted-file": { length: 32 },
+};
+
+const server = http.createServer((req, res) => {
+  const file = serverFiles[req.url as string];
+  if (file === undefined) {
+    res.writeHead(404);
+    res.end("not found");
+    return;
   }
 
-  setHeader(key: string, value: string): void {
-    this.headers[key] = value;
+  if (req.method === "HEAD") {
+    res.writeHead(200, undefined, { "content-length": file.length.toString() });
+    res.end();
+  } else if (req.method === "GET") {
+    if (typeof file === "string") {
+      const range = req.headers["range"]?.match(/bytes=(.*)-(.*)/s);
+      const start = range != null ? parseInt(range[1]) : 0;
+      const end = range != null ? parseInt(range[2]) : 0;
+
+      res.writeHead(206, undefined, {
+        "content-type": "application/octet-stream",
+      });
+      res.end(file.substring(start, end));
+    } else {
+      res.writeHead(500);
+      res.end("internal server error");
+    }
+  } else {
+    res.writeHead(400);
+    res.end("bad request");
   }
-}
-
-interface Response {
-  headers: Record<string, string | undefined>;
-  statusCode: number;
-  data: () => string;
-}
-
-let clouds: Partial<Record<string, any>> = {};
-let files: Partial<Record<string, string>> = {};
-beforeEach(() => {
-  clouds = {};
-  files = {};
 });
 
-jest.unstable_mockModule("node:fs", () => ({
-  default: {
-    createWriteStream: (path: string) => {
-      return (content: string) => (files[path] = content);
-    },
-  },
-}));
-
-jest.unstable_mockModule("node:https", () => ({
-  default: {
-    request: (url: string, { method }: any): Request =>
-      new Request(url, method),
-  },
-}));
-
-jest.unstable_mockModule("node:stream/promises", () => ({
-  default: {
-    pipeline: async (
-      source: Response,
-      destination: (content: string) => void,
-    ) => destination(source.data()),
-  },
-}));
-
-jest.unstable_mockModule("./https.js", () => ({
-  assertResponseContentType: (res: Response, expectedType: string) => {
-    expect(res.headers["content-type"]).toContain(expectedType);
-  },
-  handleErrorResponse: async (res: Response) => new Error(res.data()),
-  handleResponse: async (res: Response) => res.data(),
-  sendRequest: async (req: Request): Promise<Response> => {
-    const data = clouds[req.url];
-    if (data === undefined) {
-      return { statusCode: 404, headers: {}, data: () => "not found" };
-    }
-
-    switch (req.method) {
-      case "HEAD":
-        return {
-          statusCode: 200,
-          headers: { "content-length": data.length.toString() },
-          data: () => "",
-        };
-
-      case "GET":
-        if (typeof data === "string") {
-          const range = req.headers["range"]?.match(/bytes=(.*)-(.*)/s);
-          const start = range != null ? parseInt(range[1]) : 0;
-          const end = range != null ? parseInt(range[2]) : 0;
-          return {
-            statusCode: 206,
-            headers: {
-              "content-type": "application/octet-stream",
-              "content-length": data.length.toString(),
-            },
-            data: () => data.substring(start, end),
-          };
-        }
-    }
-
-    return { statusCode: 500, headers: {}, data: () => "something went wrong" };
-  },
-}));
+beforeAll(() => server.listen(10002));
 
 describe("get the size of files to be downloaded", () => {
-  it("should return the size of a file to be downloaded", async () => {
+  it("should return the size of a file", async () => {
     const { getDownloadFileSize } = await import("./download.js");
 
-    clouds["a-url"] = "a content";
-
-    const fileSize = await getDownloadFileSize("a-url");
-    expect(fileSize).toBe(clouds["a-url"].length);
+    const fileSize = await getDownloadFileSize("http://localhost:10002/a-file");
+    expect(fileSize).toBe(serverFiles["/a-file"].length);
   });
 
-  it("should throw an error for an invalid URL", async () => {
+  it("should throw an error for an invalid file", async () => {
     const { getDownloadFileSize } = await import("./download.js");
 
-    const prom = getDownloadFileSize("an-invalid-url");
-    await expect(prom).rejects.toThrow("not found");
+    const prom = getDownloadFileSize("http://localhost:10002/an-invalid-file");
+
+    // TODO: It should handle the case when the error message is empty.
+    await expect(prom).rejects.toThrow(" (404)");
   });
 });
 
 describe("download files", () => {
-  it("should download a file successfully", async () => {
-    const { downloadFile } = await import("./download.js");
-
-    clouds["a-url"] = "a content";
-
-    await downloadFile("a-url", "a-file");
-
-    expect(files).toEqual({ "a-file": "a content" });
+  let tempPath = "";
+  beforeAll(async () => {
+    tempPath = await fsPromises.mkdtemp(path.join(os.tmpdir(), "temp-"));
   });
 
-  it("should throw an error because of invalid content", async () => {
+  it("should download a file", async () => {
     const { downloadFile } = await import("./download.js");
 
-    clouds["a-url"] = { length: 8 };
+    const savePath = path.join(tempPath, "a-file");
+    await downloadFile("http://localhost:10002/a-file", savePath);
 
-    const prom = downloadFile("a-url", "a-file");
-    await expect(prom).rejects.toThrow("something went wrong");
+    const buffer = await fsPromises.readFile(savePath);
+    expect(buffer.toString()).toBe("a content");
   });
+
+  it("should throw an error for a corrupted file", async () => {
+    const { downloadFile } = await import("./download.js");
+
+    const savePath = path.join(tempPath, "a-corrupted-file");
+    const prom = downloadFile(
+      "http://localhost:10002/a-corrupted-file",
+      savePath,
+    );
+
+    await Promise.all([
+      expect(prom).rejects.toThrow("internal server error (500)"),
+      expect(fsPromises.stat(savePath)).rejects.toThrow(),
+    ]);
+  });
+
+  afterAll(() => fsPromises.rm(tempPath, { recursive: true }));
 });
+
+afterAll(() => server.close());

--- a/src/api/https.test.ts
+++ b/src/api/https.test.ts
@@ -1,112 +1,8 @@
 import { jest } from "@jest/globals";
 import http from "node:http";
+import stream from "node:stream";
 
 jest.unstable_mockModule("node:https", () => ({ default: http }));
-
-class Writable {
-  #writtenData = "";
-  data?: string;
-
-  write(chunk: any): void {
-    this.#writtenData += chunk;
-  }
-
-  end(): void {
-    this.data = this.#writtenData;
-  }
-}
-
-class Request extends Writable {
-  headers: Record<string, string> = {};
-
-  #onResponse?: (res: any) => void;
-  #onError?: (err: Error) => void;
-
-  setHeader(name: string, value: string): void {
-    this.headers[name] = value;
-  }
-
-  on(event: string, callback: any): void {
-    switch (event) {
-      case "response":
-        this.#onResponse = callback;
-        break;
-
-      case "error":
-        this.#onError = callback;
-        break;
-    }
-  }
-
-  response(res: any): void {
-    if (this.#onResponse !== undefined) this.#onResponse(res);
-  }
-
-  error(err: Error): void {
-    if (this.#onError !== undefined) this.#onError(err);
-  }
-}
-
-class Readable {
-  #onData?: (chunk: any) => void;
-  #onEnd?: () => void;
-
-  on(event: string, callback: any): void {
-    switch (event) {
-      case "data":
-        this.#onData = callback;
-        break;
-
-      case "end":
-        this.#onEnd = callback;
-        break;
-    }
-  }
-
-  write(chunk: any): void {
-    if (this.#onData !== undefined) this.#onData(chunk);
-  }
-
-  end(): void {
-    if (this.#onEnd !== undefined) this.#onEnd();
-  }
-
-  pipe(writable: Writable): void {
-    this.on("data", (chunk: any) => writable.write(chunk));
-    this.on("end", () => writable.end());
-  }
-}
-
-class Response extends Readable {
-  statusCode: number;
-  headers: Record<string, string | undefined>;
-
-  #onError?: (err: Error) => void;
-
-  constructor(
-    statusCode?: number,
-    headers?: Record<string, string | undefined>,
-  ) {
-    super();
-    this.statusCode = statusCode ?? 200;
-    this.headers = headers ?? {};
-  }
-
-  on(event: string, callback: any): void {
-    switch (event) {
-      case "error":
-        this.#onError = callback;
-        break;
-
-      default:
-        super.on(event, callback);
-    }
-  }
-
-  error(err: Error): void {
-    if (this.#onError !== undefined) this.#onError(err);
-  }
-}
 
 describe("create HTTPS requests for the GitHub cache API endpoint", () => {
   it("should create an HTTPS request", async () => {
@@ -130,63 +26,11 @@ describe("create HTTPS requests for the GitHub cache API endpoint", () => {
   });
 });
 
-describe("send HTTPS requests containing raw data", () => {
-  it("should send an HTTPS request", async () => {
-    const { sendRequest } = await import("./https.js");
-
-    const req = new Request();
-    const prom = sendRequest(req as any, "a message");
-
-    req.response("a response");
-
-    await expect(prom).resolves.toBe("a response");
-    expect(req.headers).toEqual({});
-    expect(req.data).toBe("a message");
-  });
-});
-
-describe("send HTTPS requests containing JSON data", () => {
-  it("should send an HTTPS request", async () => {
-    const { sendJsonRequest } = await import("./https.js");
-
-    const req = new Request();
-    const prom = sendJsonRequest(req as any, { message: "a message" });
-
-    req.response("a response");
-
-    await expect(prom).resolves.toBe("a response");
-    expect(req.headers).toEqual({ "Content-Type": "application/json" });
-    expect(req.data).toBe(JSON.stringify({ message: "a message" }));
-  });
-});
-
-describe("send HTTPS requests containing binary streams", () => {
-  it("should send an HTTPS request", async () => {
-    const { sendStreamRequest } = await import("./https.js");
-
-    const req = new Request();
-    const bin = new Readable();
-    const prom = sendStreamRequest(req as any, bin as any, 0, 1024);
-
-    bin.write("a message");
-    bin.end();
-
-    req.response("a response");
-
-    await expect(prom).resolves.toBe("a response");
-    expect(req.headers).toEqual({
-      "Content-Type": "application/octet-stream",
-      "Content-Range": "bytes 0-1024/*",
-    });
-    expect(req.data).toBe("a message");
-  });
-});
-
 describe("assert content type of HTTP responses", () => {
   it("should assert the content type of an HTTP response", async () => {
     const { assertResponseContentType } = await import("./https.js");
 
-    const res = new Response(200, { "content-type": "a-content-type" });
+    const res = { headers: { "content-type": "a-content-type" } };
     assertResponseContentType(res as any, "a-content-type");
   });
 
@@ -194,16 +38,14 @@ describe("assert content type of HTTP responses", () => {
     const { assertResponseContentType } = await import("./https.js");
 
     expect(() => {
-      const res = new Response(200, {
-        "content-type": "another-content-type",
-      });
+      const res = { headers: { "content-type": "another-content-type" } };
       assertResponseContentType(res as any, "a-content-type");
     }).toThrow(
       "expected content type of the response to be 'a-content-type', but instead got 'another-content-type'",
     );
 
     expect(() => {
-      const res = new Response();
+      const res = { headers: {} };
       assertResponseContentType(res as any, "a-content-type");
     }).toThrow(
       "expected content type of the response to be 'a-content-type', but instead got 'undefined'",
@@ -211,68 +53,109 @@ describe("assert content type of HTTP responses", () => {
   });
 });
 
-describe("handle HTTPS responses containing raw data", () => {
-  it("should handle an HTTPS response", async () => {
-    const { handleResponse } = await import("./https.js");
-
-    const res = new Response();
-    const prom = handleResponse(res as any);
-
-    res.write("a message");
-    res.end();
-
-    await expect(prom).resolves.toEqual("a message");
-  });
-});
-
-describe("handle HTTPS responses containing JSON data", () => {
-  it("should handle an HTTPS response", async () => {
-    const { handleJsonResponse } = await import("./https.js");
-
-    const res = new Response(200, { "content-type": "application/json" });
-    const prom = handleJsonResponse(res as any);
-
-    res.write(JSON.stringify({ message: "a message" }));
-    res.end();
-
-    await expect(prom).resolves.toEqual({ message: "a message" });
-  });
-});
-
-describe("handle HTTPS responses containing error data", () => {
-  it("should handle an HTTPS response containing error data in JSON", async () => {
-    const { handleErrorResponse } = await import("./https.js");
-
-    const res = new Response(500, { "content-type": "application/json" });
-    const prom = handleErrorResponse(res as any);
-
-    res.write(JSON.stringify({ message: "an error" }));
-    res.end();
-
-    await expect(prom).resolves.toEqual(new Error("an error (500)"));
+describe("echo HTTP requests", () => {
+  const server = http.createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/echo") {
+      res.writeHead(200, req.statusMessage, req.headers);
+      req.pipe(res);
+    } else if (req.method === "POST" && req.url === "/echo-error") {
+      res.writeHead(500, req.statusMessage, req.headers);
+      req.pipe(res);
+    } else {
+      res.writeHead(400);
+      res.end("bad request");
+    }
   });
 
-  it("should handle an HTTPS response containing error data in XML", async () => {
-    const { handleErrorResponse } = await import("./https.js");
+  beforeAll(() => server.listen(10001));
 
-    const res = new Response(500, { "content-type": "application/xml" });
-    const prom = handleErrorResponse(res as any);
+  it("should echo raw data", async () => {
+    const { handleResponse, sendRequest } = await import("./https.js");
 
-    res.write("<?xml><Message>an error</Message>");
-    res.end();
+    const req = http.request("http://localhost:10001/echo", { method: "POST" });
 
-    await expect(prom).resolves.toEqual(new Error("an error (500)"));
+    const res = await sendRequest(req, "a message");
+    expect(res.statusCode).toBe(200);
+
+    const data = await handleResponse(res);
+    expect(data).toBe("a message");
   });
 
-  it("should handle an HTTPS response containing error data in string", async () => {
-    const { handleErrorResponse } = await import("./https.js");
+  it("should echo JSON data", async () => {
+    const { handleJsonResponse, sendJsonRequest } = await import("./https.js");
 
-    const res = new Response(500);
-    const prom = handleErrorResponse(res as any);
+    const req = http.request("http://localhost:10001/echo", { method: "POST" });
 
-    res.write("an error");
-    res.end();
+    const res = await sendJsonRequest(req, { message: "a message" });
+    expect(res.statusCode).toBe(200);
 
-    await expect(prom).resolves.toEqual(new Error("an error (500)"));
+    const data = await handleJsonResponse(res);
+    expect(data).toEqual({
+      message: "a message",
+    });
   });
+
+  it("should echo a binary stream", async () => {
+    const { handleResponse, sendStreamRequest } = await import("./https.js");
+
+    const bin = stream.Readable.from("a message");
+    const req = http.request("http://localhost:10001/echo", { method: "POST" });
+
+    const res = await sendStreamRequest(req, bin, 16, 32);
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toBe("application/octet-stream");
+    expect(res.headers["content-range"]).toBe("bytes 16-32/*");
+
+    const data = await handleResponse(res);
+    expect(data).toBe("a message");
+  });
+
+  describe("echo error data", () => {
+    it("should echo error data in JSON", async () => {
+      const { handleErrorResponse, sendJsonRequest } = await import(
+        "./https.js"
+      );
+
+      const req = http.request("http://localhost:10001/echo-error", {
+        method: "POST",
+      });
+
+      const res = await sendJsonRequest(req, { message: "an error" });
+      expect(res.statusCode).toBe(500);
+
+      const err = await handleErrorResponse(res);
+      expect(err).toEqual(new Error("an error (500)"));
+    });
+
+    it("should echo error data in XML", async () => {
+      const { handleErrorResponse, sendRequest } = await import("./https.js");
+
+      const req = http.request("http://localhost:10001/echo-error", {
+        method: "POST",
+      });
+      req.setHeader("content-type", "application/xml");
+
+      const res = await sendRequest(req, "<?xml><Message>an error</Message>");
+      expect(res.statusCode).toBe(500);
+
+      const err = await handleErrorResponse(res);
+      expect(err).toEqual(new Error("an error (500)"));
+    });
+
+    it("should echo error data in unknown type", async () => {
+      const { handleErrorResponse, sendRequest } = await import("./https.js");
+
+      const req = http.request("http://localhost:10001/echo-error", {
+        method: "POST",
+      });
+
+      const res = await sendRequest(req, "an error");
+      expect(res.statusCode).toBe(500);
+
+      const err = await handleErrorResponse(res);
+      expect(err).toEqual(new Error("an error (500)"));
+    });
+  });
+
+  afterAll(() => server.close());
 });


### PR DESCRIPTION
This pull request resolves #112 by refactoring all tests in the `api` directory to be conducted using a real server. Refer to the changes for more details about the test refactors.