### PR TITLE
Modify Handle Response Function to Return Buffer

### DIFF
--- a/dist/post.mjs
+++ b/dist/post.mjs
@@ -106,16 +106,16 @@ function assertResponseContentType(res, expectedType) {
     }
 }
 /**
- * Handles an HTTPS response containing raw data.
+ * Handles an HTTPS response.
  *
  * @param res - The HTTPS response object.
- * @returns A promise that resolves to the raw data as a string.
+ * @returns A promise that resolves to the buffered data of the HTTPS response.
  */
 async function handleResponse(res) {
     return new Promise((resolve, reject) => {
-        let data = "";
-        res.on("data", (chunk) => (data += chunk.toString()));
-        res.on("end", () => resolve(data));
+        const chunks = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => resolve(Buffer.concat(chunks)));
         res.on("error", reject);
     });
 }
@@ -128,8 +128,8 @@ async function handleResponse(res) {
  */
 async function handleJsonResponse(res) {
     assertResponseContentType(res, "application/json");
-    const data = await handleResponse(res);
-    return JSON.parse(data);
+    const buffer = await handleResponse(res);
+    return JSON.parse(buffer.toString());
 }
 /**
  * Handles an HTTPS response containing error data.
@@ -138,23 +138,23 @@ async function handleJsonResponse(res) {
  * @returns A promise that resolves to an `Error` object.
  */
 async function handleErrorResponse(res) {
-    let data = await handleResponse(res);
+    const buffer = await handleResponse(res);
     const contentType = res.headers["content-type"];
     if (contentType !== undefined) {
         if (contentType.includes("application/json")) {
-            const jsonData = JSON.parse(data);
-            if (typeof jsonData === "object" && "message" in jsonData) {
-                data = jsonData["message"];
+            const data = JSON.parse(buffer.toString());
+            if (typeof data === "object" && "message" in data) {
+                return new Error(`${data["message"]} (${res.statusCode})`);
             }
         }
         else if (contentType.includes("application/xml")) {
-            const matchData = data.match(/<Message>(.*?)<\/Message>/s);
-            if (matchData !== null && matchData.length > 1) {
-                data = matchData[1];
+            const data = buffer.toString().match(/<Message>(.*?)<\/Message>/s);
+            if (data !== null && data.length > 1) {
+                return new Error(`${data[1]} (${res.statusCode})`);
             }
         }
     }
-    return new Error(`${data} (${res.statusCode})`);
+    return new Error(`${buffer.toString()} (${res.statusCode})`);
 }
 
 /**

--- a/src/api/https.test.ts
+++ b/src/api/https.test.ts
@@ -77,8 +77,8 @@ describe("echo HTTP requests", () => {
     const res = await sendRequest(req, "a message");
     expect(res.statusCode).toBe(200);
 
-    const data = await handleResponse(res);
-    expect(data).toBe("a message");
+    const buffer = await handleResponse(res);
+    expect(buffer.toString()).toBe("a message");
   });
 
   it("should echo JSON data", async () => {
@@ -106,8 +106,8 @@ describe("echo HTTP requests", () => {
     expect(res.headers["content-type"]).toBe("application/octet-stream");
     expect(res.headers["content-range"]).toBe("bytes 16-32/*");
 
-    const data = await handleResponse(res);
-    expect(data).toBe("a message");
+    const buffer = await handleResponse(res);
+    expect(buffer.toString()).toBe("a message");
   });
 
   describe("echo error data", () => {

--- a/src/api/https.ts
+++ b/src/api/https.ts
@@ -109,18 +109,18 @@ export function assertResponseContentType(
 }
 
 /**
- * Handles an HTTPS response containing raw data.
+ * Handles an HTTPS response.
  *
  * @param res - The HTTPS response object.
- * @returns A promise that resolves to the raw data as a string.
+ * @returns A promise that resolves to the buffered data of the HTTPS response.
  */
 export async function handleResponse(
   res: http.IncomingMessage,
-): Promise<string> {
+): Promise<Buffer> {
   return new Promise((resolve, reject) => {
-    let data = "";
-    res.on("data", (chunk) => (data += chunk.toString()));
-    res.on("end", () => resolve(data));
+    const chunks: Uint8Array[] = [];
+    res.on("data", (chunk) => chunks.push(chunk));
+    res.on("end", () => resolve(Buffer.concat(chunks)));
     res.on("error", reject);
   });
 }
@@ -136,8 +136,8 @@ export async function handleJsonResponse<T>(
   res: http.IncomingMessage,
 ): Promise<T> {
   assertResponseContentType(res, "application/json");
-  const data = await handleResponse(res);
-  return JSON.parse(data);
+  const buffer = await handleResponse(res);
+  return JSON.parse(buffer.toString());
 }
 
 /**
@@ -149,22 +149,22 @@ export async function handleJsonResponse<T>(
 export async function handleErrorResponse(
   res: http.IncomingMessage,
 ): Promise<Error> {
-  let data = await handleResponse(res);
+  const buffer = await handleResponse(res);
 
   const contentType = res.headers["content-type"];
   if (contentType !== undefined) {
     if (contentType.includes("application/json")) {
-      const jsonData = JSON.parse(data);
-      if (typeof jsonData === "object" && "message" in jsonData) {
-        data = jsonData["message"];
+      const data = JSON.parse(buffer.toString());
+      if (typeof data === "object" && "message" in data) {
+        return new Error(`${data["message"]} (${res.statusCode})`);
       }
     } else if (contentType.includes("application/xml")) {
-      const matchData = data.match(/<Message>(.*?)<\/Message>/s);
-      if (matchData !== null && matchData.length > 1) {
-        data = matchData[1];
+      const data = buffer.toString().match(/<Message>(.*?)<\/Message>/s);
+      if (data !== null && data.length > 1) {
+        return new Error(`${data[1]} (${res.statusCode})`);
       }
     }
   }
 
-  return new Error(`${data} (${res.statusCode})`);
+  return new Error(`${buffer.toString()} (${res.statusCode})`);
 }


### PR DESCRIPTION
This pull request resolves #114 by modifying the `handleResponse` function to return a `Buffer`. It also changes how the `handleResponse` function collects the buffered data received from the HTTPS response.