### PR TITLE
Make Create Cache Request Function Internal

### DIFF
--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -44,19 +44,6 @@ function logError(err) {
 }
 
 /**
- * Creates an HTTPS request for the GitHub cache API endpoint.
- *
- * @param resourcePath - The path of the resource to be accessed in the API.
- * @param options - The options for the HTTPS request (e.g., method, headers).
- * @returns An HTTPS request object.
- */
-function createRequest(resourcePath, options) {
-    const req = https.request(`${process.env["ACTIONS_CACHE_URL"]}_apis/artifactcache/${resourcePath}`, options);
-    req.setHeader("Accept", "application/json;api-version=6.0-preview");
-    req.setHeader("Authorization", `Bearer ${process.env["ACTIONS_RUNTIME_TOKEN"]}`);
-    return req;
-}
-/**
  * Sends an HTTPS request containing raw data.
  *
  * @param req - The HTTPS request object.
@@ -135,6 +122,14 @@ async function handleErrorResponse(res) {
     return new Error(`${buffer.toString()} (${res.statusCode})`);
 }
 
+function createCacheRequest(resourcePath, options) {
+    const url = `${process.env["ACTIONS_CACHE_URL"]}_apis/artifactcache/${resourcePath}`;
+    const req = https.request(url, options);
+    req.setHeader("Accept", "application/json;api-version=6.0-preview");
+    const bearer = `Bearer ${process.env["ACTIONS_RUNTIME_TOKEN"]}`;
+    req.setHeader("Authorization", bearer);
+    return req;
+}
 /**
  * Retrieves cache information for the specified key and version.
  *
@@ -143,9 +138,8 @@ async function handleErrorResponse(res) {
  * @returns A promise that resolves with the cache information or null if not found.
  */
 async function getCache(key, version) {
-    const req = createRequest(`cache?keys=${key}&version=${version}`, {
-        method: "GET",
-    });
+    const resourcePath = `cache?keys=${key}&version=${version}`;
+    const req = createCacheRequest(resourcePath, { method: "GET" });
     const res = await sendRequest(req);
     switch (res.statusCode) {
         case 200:

--- a/src/api/cache.test.ts
+++ b/src/api/cache.test.ts
@@ -23,10 +23,22 @@ type ServerHandler = (
 let serverHandler: ServerHandler = async () => false;
 
 const server = http.createServer(async (req, res) => {
-  if (!(await serverHandler(req, res))) {
-    res.writeHead(400);
-    res.end("bad request");
+  if (req.headers["authorization"] != "Bearer a-token") {
+    res.writeHead(401);
+    res.end("unauthorized");
+    return;
   }
+
+  if (req.headers["accept"] != "application/json;api-version=6.0-preview") {
+    res.writeHead(415);
+    res.end("unsupported media type");
+    return;
+  }
+
+  if (await serverHandler(req, res)) return;
+
+  res.writeHead(400);
+  res.end("bad request");
 });
 
 beforeAll(() => {

--- a/src/api/https.test.ts
+++ b/src/api/https.test.ts
@@ -1,30 +1,5 @@
-import { jest } from "@jest/globals";
 import http from "node:http";
 import stream from "node:stream";
-
-jest.unstable_mockModule("node:https", () => ({ default: http }));
-
-describe("create HTTPS requests for the GitHub cache API endpoint", () => {
-  it("should create an HTTPS request", async () => {
-    const { createRequest } = await import("./https.js");
-
-    process.env["ACTIONS_CACHE_URL"] = "http://localhost/";
-    process.env["ACTIONS_RUNTIME_TOKEN"] = "a-token";
-
-    const req = createRequest("resources", { method: "GET" });
-
-    req.on("error", () => undefined);
-    req.end();
-
-    expect(req.protocol).toBe("http:");
-    expect(req.host).toBe("localhost");
-    expect(req.path).toBe("/_apis/artifactcache/resources");
-    expect(req.getHeader("accept")).toBe(
-      "application/json;api-version=6.0-preview",
-    );
-    expect(req.getHeader("authorization")).toBe("Bearer a-token");
-  });
-});
 
 describe("assert content type of HTTP responses", () => {
   it("should assert the content type of an HTTP response", async () => {

--- a/src/api/https.ts
+++ b/src/api/https.ts
@@ -1,32 +1,5 @@
-import https from "node:https";
-
 import type http from "node:http";
 import type stream from "node:stream";
-
-/**
- * Creates an HTTPS request for the GitHub cache API endpoint.
- *
- * @param resourcePath - The path of the resource to be accessed in the API.
- * @param options - The options for the HTTPS request (e.g., method, headers).
- * @returns An HTTPS request object.
- */
-export function createRequest(
-  resourcePath: string,
-  options: https.RequestOptions,
-): http.ClientRequest {
-  const req = https.request(
-    `${process.env["ACTIONS_CACHE_URL"]}_apis/artifactcache/${resourcePath}`,
-    options,
-  );
-
-  req.setHeader("Accept", "application/json;api-version=6.0-preview");
-  req.setHeader(
-    "Authorization",
-    `Bearer ${process.env["ACTIONS_RUNTIME_TOKEN"]}`,
-  );
-
-  return req;
-}
 
 /**
  * Sends an HTTPS request containing raw data.


### PR DESCRIPTION
This pull request resolves #116 by moving the `createRequest` function from `api/https.ts` to `api/cache.ts` and renaming it to `createCacheRequest`. The function has been made internal.