### PR TITLE
Refactor HTTP Utility Functions

### DIFF
--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -44,11 +44,11 @@ function logError(err) {
 }
 
 /**
- * Sends an HTTPS request containing raw data.
+ * Sends an HTTP request containing raw data.
  *
- * @param req - The HTTPS request object.
+ * @param req - The HTTP request object.
  * @param data - The raw data to be sent in the request body.
- * @returns A promise that resolves to an HTTPS response object.
+ * @returns A promise that resolves to an HTTP response object.
  */
 async function sendRequest(req, data) {
     return new Promise((resolve, reject) => {
@@ -71,10 +71,10 @@ function assertResponseContentType(res, expectedType) {
     }
 }
 /**
- * Handles an HTTPS response.
+ * Handles an HTTP response.
  *
- * @param res - The HTTPS response object.
- * @returns A promise that resolves to the buffered data of the HTTPS response.
+ * @param res - The HTTP response object.
+ * @returns A promise that resolves to the buffered data of the HTTP response.
  */
 async function handleResponse(res) {
     return new Promise((resolve, reject) => {
@@ -85,10 +85,10 @@ async function handleResponse(res) {
     });
 }
 /**
- * Handles an HTTPS response containing JSON data.
+ * Handles an HTTP response containing JSON data.
  *
  * @typeParam T - The expected type of the parsed JSON data.
- * @param res - The HTTPS response object.
+ * @param res - The HTTP response object.
  * @returns A promise that resolves to the parsed JSON data of type T.
  */
 async function handleJsonResponse(res) {
@@ -97,9 +97,9 @@ async function handleJsonResponse(res) {
     return JSON.parse(buffer.toString());
 }
 /**
- * Handles an HTTPS response containing error data.
+ * Handles an HTTP response containing error data.
  *
- * @param res - The HTTPS response object.
+ * @param res - The HTTP response object.
  * @returns A promise that resolves to an `Error` object.
  */
 async function handleErrorResponse(res) {

--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -58,68 +58,71 @@ async function sendRequest(req, data) {
     });
 }
 /**
- * Asserts whether the content type of the given HTTP response matches the expected type.
+ * Asserts whether the content type of the given HTTP incoming message matches
+ * the expected type.
  *
- * @param res - The HTTP response.
- * @param expectedType - The expected content type of the HTTP response.
- * @throws {Error} Throws an error if the content type does not match the expected type.
+ * @param msg - The HTTP incoming message.
+ * @param expectedType - The expected content type of the message.
+ * @throws {Error} Throws an error if the content type does not match the
+ * expected type.
  */
-function assertResponseContentType(res, expectedType) {
-    const actualType = res.headers["content-type"] ?? "undefined";
+function assertIncomingMessageContentType(msg, expectedType) {
+    const actualType = msg.headers["content-type"] ?? "undefined";
     if (!actualType.includes(expectedType)) {
-        throw new Error(`expected content type of the response to be '${expectedType}', but instead got '${actualType}'`);
+        throw new Error(`expected content type to be '${expectedType}', but instead got '${actualType}'`);
     }
 }
 /**
- * Handles an HTTP response.
+ * Reads the data from an HTTP incoming message.
  *
- * @param res - The HTTP response object.
- * @returns A promise that resolves to the buffered data of the HTTP response.
+ * @param msg - The HTTP incoming message.
+ * @returns A promise that resolves to the buffered data from the message.
  */
-async function handleResponse(res) {
+async function readIncomingMessage(msg) {
     return new Promise((resolve, reject) => {
         const chunks = [];
-        res.on("data", (chunk) => chunks.push(chunk));
-        res.on("end", () => resolve(Buffer.concat(chunks)));
-        res.on("error", reject);
+        msg.on("data", (chunk) => chunks.push(chunk));
+        msg.on("end", () => resolve(Buffer.concat(chunks)));
+        msg.on("error", reject);
     });
 }
 /**
- * Handles an HTTP response containing JSON data.
+ * Reads the JSON data from an HTTP incoming message.
  *
  * @typeParam T - The expected type of the parsed JSON data.
- * @param res - The HTTP response object.
- * @returns A promise that resolves to the parsed JSON data of type T.
+ * @param msg - The HTTP incoming message.
+ * @returns A promise that resolves to the parsed JSON data from the message.
  */
-async function handleJsonResponse(res) {
-    assertResponseContentType(res, "application/json");
-    const buffer = await handleResponse(res);
+async function readJsonIncomingMessage(msg) {
+    assertIncomingMessageContentType(msg, "application/json");
+    const buffer = await readIncomingMessage(msg);
     return JSON.parse(buffer.toString());
 }
 /**
- * Handles an HTTP response containing error data.
+ * Reads the error data from an HTTP incoming message.
  *
- * @param res - The HTTP response object.
- * @returns A promise that resolves to an `Error` object.
+ * @param msg - The HTTP incoming message.
+ * @returns A promise that resolves to an `Error` object based on the error
+ * data from the message.
  */
-async function handleErrorResponse(res) {
-    const buffer = await handleResponse(res);
-    const contentType = res.headers["content-type"];
+async function readErrorIncomingMessage(msg) {
+    const buffer = await readIncomingMessage(msg);
+    const contentType = msg.headers["content-type"];
     if (contentType !== undefined) {
         if (contentType.includes("application/json")) {
             const data = JSON.parse(buffer.toString());
             if (typeof data === "object" && "message" in data) {
-                return new Error(`${data["message"]} (${res.statusCode})`);
+                return new Error(`${data["message"]} (${msg.statusCode})`);
             }
         }
         else if (contentType.includes("application/xml")) {
             const data = buffer.toString().match(/<Message>(.*?)<\/Message>/s);
             if (data !== null && data.length > 1) {
-                return new Error(`${data[1]} (${res.statusCode})`);
+                return new Error(`${data[1]} (${msg.statusCode})`);
             }
         }
     }
-    return new Error(`${buffer.toString()} (${res.statusCode})`);
+    return new Error(`${buffer.toString()} (${msg.statusCode})`);
 }
 
 function createCacheRequest(resourcePath, options) {
@@ -143,13 +146,13 @@ async function getCache(key, version) {
     const res = await sendRequest(req);
     switch (res.statusCode) {
         case 200:
-            return await handleJsonResponse(res);
+            return await readJsonIncomingMessage(res);
         // Cache not found, return null.
         case 204:
-            await handleResponse(res);
+            await readIncomingMessage(res);
             return null;
         default:
-            throw await handleErrorResponse(res);
+            throw await readErrorIncomingMessage(res);
     }
 }
 
@@ -164,11 +167,11 @@ async function getDownloadFileSize(url) {
     const res = await sendRequest(req);
     switch (res.statusCode) {
         case 200: {
-            await handleResponse(res);
+            await readIncomingMessage(res);
             return Number.parseInt(res.headers["content-length"]);
         }
         default:
-            throw await handleErrorResponse(res);
+            throw await readErrorIncomingMessage(res);
     }
 }
 /**
@@ -185,13 +188,13 @@ async function downloadFile(url, savePath) {
     const res = await sendRequest(req);
     switch (res.statusCode) {
         case 206: {
-            assertResponseContentType(res, "application/octet-stream");
+            assertIncomingMessageContentType(res, "application/octet-stream");
             const file = fs.createWriteStream(savePath);
             await streamPromises.pipeline(res, file);
             break;
         }
         default:
-            throw await handleErrorResponse(res);
+            throw await readErrorIncomingMessage(res);
     }
 }
 

--- a/dist/post.mjs
+++ b/dist/post.mjs
@@ -35,11 +35,11 @@ function logError(err) {
 }
 
 /**
- * Sends an HTTPS request containing raw data.
+ * Sends an HTTP request containing raw data.
  *
- * @param req - The HTTPS request object.
+ * @param req - The HTTP request object.
  * @param data - The raw data to be sent in the request body.
- * @returns A promise that resolves to an HTTPS response object.
+ * @returns A promise that resolves to an HTTP response object.
  */
 async function sendRequest(req, data) {
     return new Promise((resolve, reject) => {
@@ -51,24 +51,24 @@ async function sendRequest(req, data) {
     });
 }
 /**
- * Sends an HTTPS request containing JSON data.
+ * Sends an HTTP request containing JSON data.
  *
- * @param req - The HTTPS request object.
+ * @param req - The HTTP request object.
  * @param data - The JSON data to be sent in the request body.
- * @returns A promise that resolves to an HTTPS response object.
+ * @returns A promise that resolves to an HTTP response object.
  */
 async function sendJsonRequest(req, data) {
     req.setHeader("Content-Type", "application/json");
     return sendRequest(req, JSON.stringify(data));
 }
 /**
- * Sends an HTTPS request containing a binary stream.
+ * Sends an HTTP request containing a binary stream.
  *
- * @param req - The HTTPS request object.
+ * @param req - The HTTP request object.
  * @param bin - The binary stream to be sent in the request body.
  * @param start - The starting byte of the binary stream.
  * @param end - The ending byte of the binary stream.
- * @returns A promise that resolves to an HTTPS response object.
+ * @returns A promise that resolves to an HTTP response object.
  */
 async function sendStreamRequest(req, bin, start, end) {
     return new Promise((resolve, reject) => {
@@ -93,10 +93,10 @@ function assertResponseContentType(res, expectedType) {
     }
 }
 /**
- * Handles an HTTPS response.
+ * Handles an HTTP response.
  *
- * @param res - The HTTPS response object.
- * @returns A promise that resolves to the buffered data of the HTTPS response.
+ * @param res - The HTTP response object.
+ * @returns A promise that resolves to the buffered data of the HTTP response.
  */
 async function handleResponse(res) {
     return new Promise((resolve, reject) => {
@@ -107,10 +107,10 @@ async function handleResponse(res) {
     });
 }
 /**
- * Handles an HTTPS response containing JSON data.
+ * Handles an HTTP response containing JSON data.
  *
  * @typeParam T - The expected type of the parsed JSON data.
- * @param res - The HTTPS response object.
+ * @param res - The HTTP response object.
  * @returns A promise that resolves to the parsed JSON data of type T.
  */
 async function handleJsonResponse(res) {
@@ -119,9 +119,9 @@ async function handleJsonResponse(res) {
     return JSON.parse(buffer.toString());
 }
 /**
- * Handles an HTTPS response containing error data.
+ * Handles an HTTP response containing error data.
  *
- * @param res - The HTTPS response object.
+ * @param res - The HTTP response object.
  * @returns A promise that resolves to an `Error` object.
  */
 async function handleErrorResponse(res) {

--- a/src/api/cache.ts
+++ b/src/api/cache.ts
@@ -9,7 +9,7 @@ import {
   sendJsonRequest,
   sendRequest,
   sendStreamRequest,
-} from "./https.js";
+} from "./http.js";
 
 interface Cache {
   scope: string;

--- a/src/api/cache.ts
+++ b/src/api/cache.ts
@@ -3,9 +3,9 @@ import type http from "node:http";
 import https from "node:https";
 
 import {
-  handleErrorResponse,
-  handleJsonResponse,
-  handleResponse,
+  readErrorIncomingMessage,
+  readIncomingMessage,
+  readJsonIncomingMessage,
   sendJsonRequest,
   sendRequest,
   sendStreamRequest,
@@ -51,15 +51,15 @@ export async function getCache(
   const res = await sendRequest(req);
   switch (res.statusCode) {
     case 200:
-      return await handleJsonResponse<Cache>(res);
+      return await readJsonIncomingMessage<Cache>(res);
 
     // Cache not found, return null.
     case 204:
-      await handleResponse(res);
+      await readIncomingMessage(res);
       return null;
 
     default:
-      throw await handleErrorResponse(res);
+      throw await readErrorIncomingMessage(res);
   }
 }
 
@@ -82,17 +82,19 @@ export async function reserveCache(
 
   switch (res.statusCode) {
     case 201: {
-      const { cacheId } = await handleJsonResponse<{ cacheId: number }>(res);
+      const { cacheId } = await readJsonIncomingMessage<{ cacheId: number }>(
+        res,
+      );
       return cacheId;
     }
 
     // Cache already reserved, return null.
     case 409:
-      await handleResponse(res);
+      await readIncomingMessage(res);
       return null;
 
     default:
-      throw await handleErrorResponse(res);
+      throw await readErrorIncomingMessage(res);
   }
 }
 
@@ -127,11 +129,11 @@ export async function uploadCache(
 
         switch (res.statusCode) {
           case 204:
-            await handleResponse(res);
+            await readIncomingMessage(res);
             break;
 
           default:
-            throw await handleErrorResponse(res);
+            throw await readErrorIncomingMessage(res);
         }
       })(),
     );
@@ -151,7 +153,7 @@ export async function commitCache(id: number, size: number): Promise<void> {
   const req = createCacheRequest(`caches/${id}`, { method: "POST" });
   const res = await sendJsonRequest(req, { size });
   if (res.statusCode !== 204) {
-    throw await handleErrorResponse(res);
+    throw await readErrorIncomingMessage(res);
   }
-  await handleResponse(res);
+  await readIncomingMessage(res);
 }

--- a/src/api/download.ts
+++ b/src/api/download.ts
@@ -3,9 +3,9 @@ import https from "node:https";
 import streamPromises from "node:stream/promises";
 
 import {
-  assertResponseContentType,
-  handleErrorResponse,
-  handleResponse,
+  assertIncomingMessageContentType,
+  readErrorIncomingMessage,
+  readIncomingMessage,
   sendRequest,
 } from "./http.js";
 
@@ -21,12 +21,12 @@ export async function getDownloadFileSize(url: string): Promise<number> {
 
   switch (res.statusCode) {
     case 200: {
-      await handleResponse(res);
+      await readIncomingMessage(res);
       return Number.parseInt(res.headers["content-length"] as string);
     }
 
     default:
-      throw await handleErrorResponse(res);
+      throw await readErrorIncomingMessage(res);
   }
 }
 
@@ -50,13 +50,13 @@ export async function downloadFile(
 
   switch (res.statusCode) {
     case 206: {
-      assertResponseContentType(res, "application/octet-stream");
+      assertIncomingMessageContentType(res, "application/octet-stream");
       const file = fs.createWriteStream(savePath);
       await streamPromises.pipeline(res, file);
       break;
     }
 
     default:
-      throw await handleErrorResponse(res);
+      throw await readErrorIncomingMessage(res);
   }
 }

--- a/src/api/download.ts
+++ b/src/api/download.ts
@@ -7,7 +7,7 @@ import {
   handleErrorResponse,
   handleResponse,
   sendRequest,
-} from "./https.js";
+} from "./http.js";
 
 /**
  * Retrieves the file size of a file to be downloaded from the specified URL.

--- a/src/api/http.test.ts
+++ b/src/api/http.test.ts
@@ -3,14 +3,14 @@ import stream from "node:stream";
 
 describe("assert content type of HTTP responses", () => {
   it("should assert the content type of an HTTP response", async () => {
-    const { assertResponseContentType } = await import("./https.js");
+    const { assertResponseContentType } = await import("./http.js");
 
     const res = { headers: { "content-type": "a-content-type" } };
     assertResponseContentType(res as any, "a-content-type");
   });
 
   it("should fail to assert the content type of HTTP responses", async () => {
-    const { assertResponseContentType } = await import("./https.js");
+    const { assertResponseContentType } = await import("./http.js");
 
     expect(() => {
       const res = { headers: { "content-type": "another-content-type" } };
@@ -45,7 +45,7 @@ describe("echo HTTP requests", () => {
   beforeAll(() => server.listen(10001));
 
   it("should echo raw data", async () => {
-    const { handleResponse, sendRequest } = await import("./https.js");
+    const { handleResponse, sendRequest } = await import("./http.js");
 
     const req = http.request("http://localhost:10001/echo", { method: "POST" });
 
@@ -57,7 +57,7 @@ describe("echo HTTP requests", () => {
   });
 
   it("should echo JSON data", async () => {
-    const { handleJsonResponse, sendJsonRequest } = await import("./https.js");
+    const { handleJsonResponse, sendJsonRequest } = await import("./http.js");
 
     const req = http.request("http://localhost:10001/echo", { method: "POST" });
 
@@ -71,7 +71,7 @@ describe("echo HTTP requests", () => {
   });
 
   it("should echo a binary stream", async () => {
-    const { handleResponse, sendStreamRequest } = await import("./https.js");
+    const { handleResponse, sendStreamRequest } = await import("./http.js");
 
     const bin = stream.Readable.from("a message");
     const req = http.request("http://localhost:10001/echo", { method: "POST" });
@@ -88,7 +88,7 @@ describe("echo HTTP requests", () => {
   describe("echo error data", () => {
     it("should echo error data in JSON", async () => {
       const { handleErrorResponse, sendJsonRequest } = await import(
-        "./https.js"
+        "./http.js"
       );
 
       const req = http.request("http://localhost:10001/echo-error", {
@@ -103,7 +103,7 @@ describe("echo HTTP requests", () => {
     });
 
     it("should echo error data in XML", async () => {
-      const { handleErrorResponse, sendRequest } = await import("./https.js");
+      const { handleErrorResponse, sendRequest } = await import("./http.js");
 
       const req = http.request("http://localhost:10001/echo-error", {
         method: "POST",
@@ -118,7 +118,7 @@ describe("echo HTTP requests", () => {
     });
 
     it("should echo error data in unknown type", async () => {
-      const { handleErrorResponse, sendRequest } = await import("./https.js");
+      const { handleErrorResponse, sendRequest } = await import("./http.js");
 
       const req = http.request("http://localhost:10001/echo-error", {
         method: "POST",

--- a/src/api/http.test.ts
+++ b/src/api/http.test.ts
@@ -1,29 +1,29 @@
 import http from "node:http";
 import stream from "node:stream";
 
-describe("assert content type of HTTP responses", () => {
-  it("should assert the content type of an HTTP response", async () => {
-    const { assertResponseContentType } = await import("./http.js");
+describe("assert content type of HTTP incoming messages", () => {
+  it("should assert the content type", async () => {
+    const { assertIncomingMessageContentType } = await import("./http.js");
 
     const res = { headers: { "content-type": "a-content-type" } };
-    assertResponseContentType(res as any, "a-content-type");
+    assertIncomingMessageContentType(res as any, "a-content-type");
   });
 
-  it("should fail to assert the content type of HTTP responses", async () => {
-    const { assertResponseContentType } = await import("./http.js");
+  it("should fail to assert the content type", async () => {
+    const { assertIncomingMessageContentType } = await import("./http.js");
 
     expect(() => {
       const res = { headers: { "content-type": "another-content-type" } };
-      assertResponseContentType(res as any, "a-content-type");
+      assertIncomingMessageContentType(res as any, "a-content-type");
     }).toThrow(
-      "expected content type of the response to be 'a-content-type', but instead got 'another-content-type'",
+      "expected content type to be 'a-content-type', but instead got 'another-content-type'",
     );
 
     expect(() => {
       const res = { headers: {} };
-      assertResponseContentType(res as any, "a-content-type");
+      assertIncomingMessageContentType(res as any, "a-content-type");
     }).toThrow(
-      "expected content type of the response to be 'a-content-type', but instead got 'undefined'",
+      "expected content type to be 'a-content-type', but instead got 'undefined'",
     );
   });
 });
@@ -45,33 +45,37 @@ describe("echo HTTP requests", () => {
   beforeAll(() => server.listen(10001));
 
   it("should echo raw data", async () => {
-    const { handleResponse, sendRequest } = await import("./http.js");
+    const { readIncomingMessage, sendRequest } = await import("./http.js");
 
     const req = http.request("http://localhost:10001/echo", { method: "POST" });
 
     const res = await sendRequest(req, "a message");
     expect(res.statusCode).toBe(200);
 
-    const buffer = await handleResponse(res);
+    const buffer = await readIncomingMessage(res);
     expect(buffer.toString()).toBe("a message");
   });
 
   it("should echo JSON data", async () => {
-    const { handleJsonResponse, sendJsonRequest } = await import("./http.js");
+    const { readJsonIncomingMessage, sendJsonRequest } = await import(
+      "./http.js"
+    );
 
     const req = http.request("http://localhost:10001/echo", { method: "POST" });
 
     const res = await sendJsonRequest(req, { message: "a message" });
     expect(res.statusCode).toBe(200);
 
-    const data = await handleJsonResponse(res);
+    const data = await readJsonIncomingMessage(res);
     expect(data).toEqual({
       message: "a message",
     });
   });
 
   it("should echo a binary stream", async () => {
-    const { handleResponse, sendStreamRequest } = await import("./http.js");
+    const { readIncomingMessage, sendStreamRequest } = await import(
+      "./http.js"
+    );
 
     const bin = stream.Readable.from("a message");
     const req = http.request("http://localhost:10001/echo", { method: "POST" });
@@ -81,13 +85,13 @@ describe("echo HTTP requests", () => {
     expect(res.headers["content-type"]).toBe("application/octet-stream");
     expect(res.headers["content-range"]).toBe("bytes 16-32/*");
 
-    const buffer = await handleResponse(res);
+    const buffer = await readIncomingMessage(res);
     expect(buffer.toString()).toBe("a message");
   });
 
   describe("echo error data", () => {
     it("should echo error data in JSON", async () => {
-      const { handleErrorResponse, sendJsonRequest } = await import(
+      const { readErrorIncomingMessage, sendJsonRequest } = await import(
         "./http.js"
       );
 
@@ -98,12 +102,14 @@ describe("echo HTTP requests", () => {
       const res = await sendJsonRequest(req, { message: "an error" });
       expect(res.statusCode).toBe(500);
 
-      const err = await handleErrorResponse(res);
+      const err = await readErrorIncomingMessage(res);
       expect(err).toEqual(new Error("an error (500)"));
     });
 
     it("should echo error data in XML", async () => {
-      const { handleErrorResponse, sendRequest } = await import("./http.js");
+      const { readErrorIncomingMessage, sendRequest } = await import(
+        "./http.js"
+      );
 
       const req = http.request("http://localhost:10001/echo-error", {
         method: "POST",
@@ -113,12 +119,14 @@ describe("echo HTTP requests", () => {
       const res = await sendRequest(req, "<?xml><Message>an error</Message>");
       expect(res.statusCode).toBe(500);
 
-      const err = await handleErrorResponse(res);
+      const err = await readErrorIncomingMessage(res);
       expect(err).toEqual(new Error("an error (500)"));
     });
 
     it("should echo error data in unknown type", async () => {
-      const { handleErrorResponse, sendRequest } = await import("./http.js");
+      const { readErrorIncomingMessage, sendRequest } = await import(
+        "./http.js"
+      );
 
       const req = http.request("http://localhost:10001/echo-error", {
         method: "POST",
@@ -127,7 +135,7 @@ describe("echo HTTP requests", () => {
       const res = await sendRequest(req, "an error");
       expect(res.statusCode).toBe(500);
 
-      const err = await handleErrorResponse(res);
+      const err = await readErrorIncomingMessage(res);
       expect(err).toEqual(new Error("an error (500)"));
     });
   });

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -2,11 +2,11 @@ import type http from "node:http";
 import type stream from "node:stream";
 
 /**
- * Sends an HTTPS request containing raw data.
+ * Sends an HTTP request containing raw data.
  *
- * @param req - The HTTPS request object.
+ * @param req - The HTTP request object.
  * @param data - The raw data to be sent in the request body.
- * @returns A promise that resolves to an HTTPS response object.
+ * @returns A promise that resolves to an HTTP response object.
  */
 export async function sendRequest(
   req: http.ClientRequest,
@@ -22,11 +22,11 @@ export async function sendRequest(
 }
 
 /**
- * Sends an HTTPS request containing JSON data.
+ * Sends an HTTP request containing JSON data.
  *
- * @param req - The HTTPS request object.
+ * @param req - The HTTP request object.
  * @param data - The JSON data to be sent in the request body.
- * @returns A promise that resolves to an HTTPS response object.
+ * @returns A promise that resolves to an HTTP response object.
  */
 export async function sendJsonRequest(
   req: http.ClientRequest,
@@ -37,13 +37,13 @@ export async function sendJsonRequest(
 }
 
 /**
- * Sends an HTTPS request containing a binary stream.
+ * Sends an HTTP request containing a binary stream.
  *
- * @param req - The HTTPS request object.
+ * @param req - The HTTP request object.
  * @param bin - The binary stream to be sent in the request body.
  * @param start - The starting byte of the binary stream.
  * @param end - The ending byte of the binary stream.
- * @returns A promise that resolves to an HTTPS response object.
+ * @returns A promise that resolves to an HTTP response object.
  */
 export async function sendStreamRequest(
   req: http.ClientRequest,
@@ -82,10 +82,10 @@ export function assertResponseContentType(
 }
 
 /**
- * Handles an HTTPS response.
+ * Handles an HTTP response.
  *
- * @param res - The HTTPS response object.
- * @returns A promise that resolves to the buffered data of the HTTPS response.
+ * @param res - The HTTP response object.
+ * @returns A promise that resolves to the buffered data of the HTTP response.
  */
 export async function handleResponse(
   res: http.IncomingMessage,
@@ -99,10 +99,10 @@ export async function handleResponse(
 }
 
 /**
- * Handles an HTTPS response containing JSON data.
+ * Handles an HTTP response containing JSON data.
  *
  * @typeParam T - The expected type of the parsed JSON data.
- * @param res - The HTTPS response object.
+ * @param res - The HTTP response object.
  * @returns A promise that resolves to the parsed JSON data of type T.
  */
 export async function handleJsonResponse<T>(
@@ -114,9 +114,9 @@ export async function handleJsonResponse<T>(
 }
 
 /**
- * Handles an HTTPS response containing error data.
+ * Handles an HTTP response containing error data.
  *
- * @param res - The HTTPS response object.
+ * @param res - The HTTP response object.
  * @returns A promise that resolves to an `Error` object.
  */
 export async function handleErrorResponse(


### PR DESCRIPTION
This pull request resolves #118 by refactoring the following:

- Renaming the `api/https.ts` file to `api/http.ts`.
- Renaming the handle response functions to `readIncomingMessage` functions.
- Utilizing the `readIncomingMessage` function in the `api/cache.test.ts` test file.