### PR TITLE
Add Function to Wait for Incoming Message

### DIFF
--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -73,6 +73,21 @@ function assertIncomingMessageContentType(msg, expectedType) {
     }
 }
 /**
+ * Waits until an HTTP incoming message has ended.
+ *
+ * @param msg - The HTTP incoming message.
+ * @returns A promise that resolves when the incoming message ends.
+ */
+async function waitIncomingMessage(msg) {
+    return new Promise((resolve, reject) => {
+        msg.on("data", () => {
+            /** discarded **/
+        });
+        msg.on("end", resolve);
+        msg.on("error", reject);
+    });
+}
+/**
  * Reads the data from an HTTP incoming message.
  *
  * @param msg - The HTTP incoming message.
@@ -149,7 +164,7 @@ async function getCache(key, version) {
             return await readJsonIncomingMessage(res);
         // Cache not found, return null.
         case 204:
-            await readIncomingMessage(res);
+            await waitIncomingMessage(res);
             return null;
         default:
             throw await readErrorIncomingMessage(res);

--- a/dist/post.mjs
+++ b/dist/post.mjs
@@ -95,6 +95,21 @@ function assertIncomingMessageContentType(msg, expectedType) {
     }
 }
 /**
+ * Waits until an HTTP incoming message has ended.
+ *
+ * @param msg - The HTTP incoming message.
+ * @returns A promise that resolves when the incoming message ends.
+ */
+async function waitIncomingMessage(msg) {
+    return new Promise((resolve, reject) => {
+        msg.on("data", () => {
+            /** discarded **/
+        });
+        msg.on("end", resolve);
+        msg.on("error", reject);
+    });
+}
+/**
  * Reads the data from an HTTP incoming message.
  *
  * @param msg - The HTTP incoming message.
@@ -174,7 +189,7 @@ async function reserveCache(key, version, size) {
         }
         // Cache already reserved, return null.
         case 409:
-            await readIncomingMessage(res);
+            await waitIncomingMessage(res);
             return null;
         default:
             throw await readErrorIncomingMessage(res);
@@ -202,7 +217,7 @@ async function uploadCache(id, filePath, fileSize, options) {
             const res = await sendStreamRequest(req, bin, start, end);
             switch (res.statusCode) {
                 case 204:
-                    await readIncomingMessage(res);
+                    await waitIncomingMessage(res);
                     break;
                 default:
                     throw await readErrorIncomingMessage(res);
@@ -224,7 +239,7 @@ async function commitCache(id, size) {
     if (res.statusCode !== 204) {
         throw await readErrorIncomingMessage(res);
     }
-    await readIncomingMessage(res);
+    await waitIncomingMessage(res);
 }
 
 /**

--- a/src/api/cache.ts
+++ b/src/api/cache.ts
@@ -4,11 +4,11 @@ import https from "node:https";
 
 import {
   readErrorIncomingMessage,
-  readIncomingMessage,
   readJsonIncomingMessage,
   sendJsonRequest,
   sendRequest,
   sendStreamRequest,
+  waitIncomingMessage,
 } from "./http.js";
 
 interface Cache {
@@ -55,7 +55,7 @@ export async function getCache(
 
     // Cache not found, return null.
     case 204:
-      await readIncomingMessage(res);
+      await waitIncomingMessage(res);
       return null;
 
     default:
@@ -90,7 +90,7 @@ export async function reserveCache(
 
     // Cache already reserved, return null.
     case 409:
-      await readIncomingMessage(res);
+      await waitIncomingMessage(res);
       return null;
 
     default:
@@ -129,7 +129,7 @@ export async function uploadCache(
 
         switch (res.statusCode) {
           case 204:
-            await readIncomingMessage(res);
+            await waitIncomingMessage(res);
             break;
 
           default:
@@ -155,5 +155,5 @@ export async function commitCache(id: number, size: number): Promise<void> {
   if (res.statusCode !== 204) {
     throw await readErrorIncomingMessage(res);
   }
-  await readIncomingMessage(res);
+  await waitIncomingMessage(res);
 }

--- a/src/api/http.test.ts
+++ b/src/api/http.test.ts
@@ -44,6 +44,17 @@ describe("echo HTTP requests", () => {
 
   beforeAll(() => server.listen(10001));
 
+  it("should echo and discard raw data", async () => {
+    const { sendRequest, waitIncomingMessage } = await import("./http.js");
+
+    const req = http.request("http://localhost:10001/echo", { method: "POST" });
+
+    const res = await sendRequest(req, "a message");
+    expect(res.statusCode).toBe(200);
+
+    await waitIncomingMessage(res);
+  });
+
   it("should echo raw data", async () => {
     const { readIncomingMessage, sendRequest } = await import("./http.js");
 

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -84,6 +84,24 @@ export function assertIncomingMessageContentType(
 }
 
 /**
+ * Waits until an HTTP incoming message has ended.
+ *
+ * @param msg - The HTTP incoming message.
+ * @returns A promise that resolves when the incoming message ends.
+ */
+export async function waitIncomingMessage(
+  msg: http.IncomingMessage,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    msg.on("data", () => {
+      /** discarded **/
+    });
+    msg.on("end", resolve);
+    msg.on("error", reject);
+  });
+}
+
+/**
  * Reads the data from an HTTP incoming message.
  *
  * @param msg - The HTTP incoming message.


### PR DESCRIPTION
This pull request resolves #120 by adding a new `waitIncomingMessage` function along with its tests and implementing it in some code as a replacement for the `readIncomingMessage` function where the return value is not being used.