### PR TITLE
Fix Unresolved Dependency Warnings When Bundling Library

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import { nodeResolve } from "@rollup/plugin-node-resolve";
+import { builtinModules } from "node:module";
 import ts from "rollup-plugin-ts";
 
 const output = {
@@ -16,6 +17,7 @@ export default [
         transpileOnly: true,
       }),
     ],
+    external: builtinModules.map((module) => `node:${module}`),
   },
   {
     input: "src/main.ts",


### PR DESCRIPTION
This pull request resolves #131 by specifying the Node.js built-in modules as external modules when bundling the library.