### PR TITLE
Deploy API Documentation to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,41 @@
+name: Deploy
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+jobs:
+  deploy-docs:
+    name: Deploy Documentation
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pages: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy-docs.outputs.page_url }}
+    concurrency:
+      group: pages
+      cancel-in-progress: true
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v4.1.7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.3
+        with:
+          node-version-file: .nvmrc
+
+      - name: Setup Yarn
+        uses: threeal/setup-yarn-action@v2.0.0
+
+      - name: Build Documentation
+        run: yarn docs
+
+      - name: Upload Documentation
+        uses: actions/upload-pages-artifact@v3.0.1
+        with:
+          path: docs
+
+      - name: Deploy Documentation
+        id: deploy-docs
+        uses: actions/deploy-pages@v4.0.5

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "action",
     "cache"
   ],
-  "homepage": "https://github.com/threeal/cache-action#readme",
+  "homepage": "https://threeal.github.io/cache-action",
   "bugs": {
     "url": "https://github.com/threeal/cache-action/issues",
     "email": "alfi.maulana.f@gmail.com"


### PR DESCRIPTION
This pull request resolves #130 by adding a new `deploy` workflow for deploying API documentation to GitHub Pages. It also updates the package's homepage URL to point to the deployed GitHub Pages URL.