### PR TITLE
Use `.js` Extension for Distributed Library Script File

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Use the following snippet to include the action in a GitHub workflow:
 
 ```yaml
 - name: Cache Dependencies
-  uses: threeal/cache-action@v0.2.0
+  uses: threeal/cache-action@v0.2.1
   with:
     key: a-key
     version: a-version
@@ -51,7 +51,7 @@ jobs:
 
       - name: Cache Dependencies
         id: cache-deps
-        uses: threeal/cache-action@v0.2.0
+        uses: threeal/cache-action@v0.2.1
         with:
           key: node-deps
           version: ${{ hashFiles('package-lock.json') }}

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
   "license": "MIT",
   "author": "Alfi Maulana <alfi.maulana.f@gmail.com>",
   "type": "module",
-  "main": "dist/lib.mjs",
-  "types": "dist/lib.d.mts",
+  "main": "dist/lib.js",
+  "types": "dist/lib.d.ts",
   "files": [
-    "dist/lib.mjs",
-    "dist/lib.d.mts"
+    "dist/lib.js",
+    "dist/lib.d.ts"
   ],
   "scripts": {
     "build": "rollup -c",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-action",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Save and restore files as a cache in GitHub Actions",
   "keywords": [
     "github",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,15 +2,12 @@ import { nodeResolve } from "@rollup/plugin-node-resolve";
 import { builtinModules } from "node:module";
 import ts from "rollup-plugin-ts";
 
-const output = {
-  dir: "dist",
-  entryFileNames: "[name].mjs",
-};
-
 export default [
   {
     input: "src/lib.ts",
-    output,
+    output: {
+      dir: "dist",
+    },
     plugins: [
       ts({
         tsconfig: (config) => ({ ...config, declaration: true }),
@@ -21,12 +18,18 @@ export default [
   },
   {
     input: "src/main.ts",
-    output,
+    output: {
+      dir: "dist",
+      entryFileNames: "[name].mjs",
+    },
     plugins: [nodeResolve(), ts({ transpileOnly: true })],
   },
   {
     input: "src/post.ts",
-    output,
+    output: {
+      dir: "dist",
+      entryFileNames: "[name].mjs",
+    },
     plugins: [nodeResolve(), ts({ transpileOnly: true })],
   },
 ];


### PR DESCRIPTION
This pull request resolves #143 by modifying the distributed library script file to use the `.js` extension instead of the `.mjs` extension. It also bumps the project version to 0.2.1.