### PR TITLE
Skip Saving If Cache is Successfully Restored

### DIFF
--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -41,6 +41,18 @@ async function setOutput(name, value) {
     const filePath = mustGetEnvironment("GITHUB_OUTPUT");
     await fsPromises.appendFile(filePath, `${name}=${value}${os.EOL}`);
 }
+/**
+ * Sets the value of a GitHub Actions state.
+ *
+ * @param name - The name of the GitHub Actions state.
+ * @param value - The value to set for the GitHub Actions state.
+ * @returns A promise that resolves when the value is successfully set.
+ */
+async function setState(name, value) {
+    process.env[`STATE_${name}`] = value;
+    const filePath = mustGetEnvironment("GITHUB_STATE");
+    await fsPromises.appendFile(filePath, `${name}=${value}${os.EOL}`);
+}
 
 /**
  * Logs an information message in GitHub Actions.
@@ -310,11 +322,17 @@ try {
     logInfo("Restoring cache...");
     if (await restoreCache(key, version)) {
         logInfo("Cache successfully restored");
-        await setOutput("restored", "true");
+        await Promise.all([
+            setOutput("restored", "true"),
+            setState("restored", "true"),
+        ]);
     }
     else {
         logInfo("Cache does not exist");
-        await setOutput("restored", "false");
+        await Promise.all([
+            setOutput("restored", "false"),
+            setState("restored", "false"),
+        ]);
     }
 }
 catch (err) {

--- a/dist/post.mjs
+++ b/dist/post.mjs
@@ -15,6 +15,16 @@ function getInput(name) {
     const value = process.env[`INPUT_${name.toUpperCase()}`] ?? "";
     return value.trim();
 }
+/**
+ * Retrieves the value of a GitHub Actions state.
+ *
+ * @param name - The name of the GitHub Actions state.
+ * @returns The value of the GitHub Actions state, or an empty string if not found.
+ */
+function getState(name) {
+    const value = process.env[`STATE_${name}`] ?? "";
+    return value.trim();
+}
 
 /**
  * Logs an information message in GitHub Actions.
@@ -310,17 +320,22 @@ async function saveCache(key, version, filePaths) {
 }
 
 try {
-    const key = getInput("key");
-    const version = getInput("version");
-    const filePaths = getInput("files")
-        .split(/\s+/)
-        .filter((arg) => arg != "");
-    logInfo("Saving cache...");
-    if (await saveCache(key, version, filePaths)) {
-        logInfo("Cache successfully saved");
+    if (getState("restored") === "true") {
+        logInfo("Cache already restored, skipping cache save");
     }
     else {
-        logInfo("Cache already exists");
+        const key = getInput("key");
+        const version = getInput("version");
+        const filePaths = getInput("files")
+            .split(/\s+/)
+            .filter((arg) => arg != "");
+        logInfo("Saving cache...");
+        if (await saveCache(key, version, filePaths)) {
+            logInfo("Cache successfully saved");
+        }
+        else {
+            logInfo("Aborting cache save, cache already exists");
+        }
     }
 }
 catch (err) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { getInput, logError, logInfo, setOutput } from "gha-utils";
+import { getInput, logError, logInfo, setOutput, setState } from "gha-utils";
 import { restoreCache } from "./lib.js";
 
 try {
@@ -8,10 +8,16 @@ try {
   logInfo("Restoring cache...");
   if (await restoreCache(key, version)) {
     logInfo("Cache successfully restored");
-    await setOutput("restored", "true");
+    await Promise.all([
+      setOutput("restored", "true"),
+      setState("restored", "true"),
+    ]);
   } else {
     logInfo("Cache does not exist");
-    await setOutput("restored", "false");
+    await Promise.all([
+      setOutput("restored", "false"),
+      setState("restored", "false"),
+    ]);
   }
 } catch (err) {
   logError(err);

--- a/src/post.ts
+++ b/src/post.ts
@@ -1,18 +1,22 @@
-import { getInput, logError, logInfo } from "gha-utils";
+import { getInput, getState, logError, logInfo } from "gha-utils";
 import { saveCache } from "./lib.js";
 
 try {
-  const key = getInput("key");
-  const version = getInput("version");
-  const filePaths = getInput("files")
-    .split(/\s+/)
-    .filter((arg) => arg != "");
-
-  logInfo("Saving cache...");
-  if (await saveCache(key, version, filePaths)) {
-    logInfo("Cache successfully saved");
+  if (getState("restored") === "true") {
+    logInfo("Cache already restored, skipping cache save");
   } else {
-    logInfo("Cache already exists");
+    const key = getInput("key");
+    const version = getInput("version");
+    const filePaths = getInput("files")
+      .split(/\s+/)
+      .filter((arg) => arg != "");
+
+    logInfo("Saving cache...");
+    if (await saveCache(key, version, filePaths)) {
+      logInfo("Cache successfully saved");
+    } else {
+      logInfo("Aborting cache save, cache already exists");
+    }
   }
 } catch (err) {
   logError(err);


### PR DESCRIPTION
This pull request resolves #154 by modifying the action to skip saving if the cache is already restored. This is done by passing a `restored` state from the main step to the post step, allowing the post step to skip saving if the cache is already restored in the main step.