### PR TITLE
Treat Warnings as Errors When Building Documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "build": "rollup -c",
-    "docs": "typedoc --highlightLanguages yaml src/lib.ts",
+    "docs": "typedoc src/lib.ts",
     "format": "prettier --write --cache . !dist",
     "lint": "eslint",
     "prepack": "rollup -c",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,4 +1,4 @@
 {
-  "highlightLanguages": ["yaml"],
+  "highlightLanguages": ["bash", "js", "yaml"],
   "treatWarningsAsErrors": true
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,3 +1,4 @@
 {
-  "highlightLanguages": ["yaml"]
+  "highlightLanguages": ["yaml"],
+  "treatWarningsAsErrors": true
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,3 @@
+{
+  "highlightLanguages": ["yaml"]
+}


### PR DESCRIPTION
This pull request resolves #164 by treating warnings as errors when building documentation using TypeDoc. It also updates TypeDoc to use the `typedoc.json` configuration file instead of specifying options in the command arguments.