### PR TITLE
Fix Build Workflow Not Building Documentation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: threeal/setup-yarn-action@v2.0.0
 
       - name: Build Documentation
-        run: yarn pack
+        run: yarn docs
 
       - name: Upload Documentation
         uses: actions/upload-artifact@v4.4.0


### PR DESCRIPTION
This pull request resolves #168 by simply fixing a typo in the `build` workflow, where it incorrectly uses the `yarn pack` command to build the documentation instead of the correct `yarn docs` command.