### PR TITLE
Add Save Sub Action

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 dist/** -diff linguist-generated
 restore/dist/** -diff linguist-generated
+save/dist/** -diff linguist-generated
 yarn.lock -diff linguist-generated

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,38 +37,14 @@ jobs:
           path: cache-action
           sparse-checkout: |
             dist
-            restore/dist
-            restore/action.yaml
             action.yml
           sparse-checkout-cone-mode: false
-
-      - name: Prepare Files
-        shell: bash
-        run: |
-          echo "a content" >> a-file
-          echo "another content" >> another-file
-          mkdir a-dir
-          echo "a content" >> a-dir/a-file
-
-      - name: Restore Cache
-        id: restore-cache
-        uses: ./cache-action/restore
-        with:
-          key: some-key-${{ matrix.os }}
-          version: ${{ github.run_id }}
-          files: |
-            a-file another-file
-            a-dir/a-file
-
-      - name: Check Output
-        shell: bash
-        run: test "${{ steps.restore-cache.outputs.restored }}" == "false"
 
       - name: Save Cache
         id: save-cache
         uses: ./cache-action
         with:
-          key: some-key-${{ matrix.os }}
+          key: a-key-${{ matrix.os }}
           version: ${{ github.run_id }}
           files: |
             a-file another-file
@@ -77,6 +53,14 @@ jobs:
       - name: Check Output
         shell: bash
         run: test "${{ steps.save-cache.outputs.restored }}" == "false"
+
+      - name: Prepare Files
+        shell: bash
+        run: |
+          echo "a content" >> a-file
+          echo "another content" >> another-file
+          mkdir a-dir
+          echo "a content" >> a-dir/a-file
 
   test-action-restore-file:
     name: Test Action to Restore File
@@ -92,15 +76,15 @@ jobs:
         with:
           path: cache-action
           sparse-checkout: |
-            action.yml
             dist
+            action.yml
           sparse-checkout-cone-mode: false
 
       - name: Restore Cache
         id: restore-cache
         uses: ./cache-action
         with:
-          key: some-key-${{ matrix.os }}
+          key: a-key-${{ matrix.os }}
           version: ${{ github.run_id }}
           files: |
             a-file another-file
@@ -117,8 +101,8 @@ jobs:
           test "$(cat another-file)" == "another content"
           test "$(cat a-dir/a-file)" == "a content"
 
-  test-restore-action-restore-file:
-    name: Test Restore Action to Restore File
+  test-restore-and-save-sub-actions:
+    name: Test Restore and Save Sub-Actions
     needs: test-action-save-file
     runs-on: ${{ matrix.os }}
     strategy:
@@ -133,13 +117,15 @@ jobs:
           sparse-checkout: |
             restore/dist
             restore/action.yml
+            save/dist
+            save/action.yml
           sparse-checkout-cone-mode: false
 
-      - name: Restore Cache
-        id: restore-cache
+      - name: Restore Non-Existing Cache
+        id: restore-non-existing-cache
         uses: ./cache-action/restore
         with:
-          key: some-key-${{ matrix.os }}
+          key: another-key-${{ matrix.os }}
           version: ${{ github.run_id }}
           files: |
             a-file another-file
@@ -147,7 +133,50 @@ jobs:
 
       - name: Check Output
         shell: bash
-        run: test "${{ steps.restore-cache.outputs.restored }}" == "true"
+        run: test "${{ steps.restore-non-existing-cache.outputs.restored }}" == "false"
+
+      - name: Prepare Files
+        shell: bash
+        run: |
+          echo "a content" >> a-file
+          echo "another content" >> another-file
+          mkdir a-dir
+          echo "a content" >> a-dir/a-file
+
+      - name: Save Non-Existing Cache
+        id: save-non-existing-cache
+        uses: ./cache-action/save
+        with:
+          key: another-key-${{ matrix.os }}
+          version: ${{ github.run_id }}
+          files: |
+            a-file another-file
+            a-dir/a-file
+
+      - name: Check Output
+        shell: bash
+        run: test "${{ steps.save-non-existing-cache.outputs.saved }}" == "true"
+
+      - name: Remove Files
+        shell: bash
+        run: |
+          rm a-file
+          rm another-file
+          rm -r a-dir
+
+      - name: Restore Existing Cache
+        id: restore-existing-cache
+        uses: ./cache-action/restore
+        with:
+          key: another-key-${{ matrix.os }}
+          version: ${{ github.run_id }}
+          files: |
+            a-file another-file
+            a-dir/a-file
+
+      - name: Check Output
+        shell: bash
+        run: test "${{ steps.restore-existing-cache.outputs.restored }}" == "true"
 
       - name: Check Files
         shell: bash
@@ -155,3 +184,17 @@ jobs:
           test "$(cat a-file)" == "a content"
           test "$(cat another-file)" == "another content"
           test "$(cat a-dir/a-file)" == "a content"
+
+      - name: Save Existing Cache
+        id: save-existing-cache
+        uses: ./cache-action/save
+        with:
+          key: another-key-${{ matrix.os }}
+          version: ${{ github.run_id }}
+          files: |
+            a-file another-file
+            a-dir/a-file
+
+      - name: Check Output
+        shell: bash
+        run: test "${{ steps.save-existing-cache.outputs.saved }}" == "false"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Use the following snippet to include the action in a GitHub workflow:
 
 By default, the action will attempt to restore files from a cache if it exists; otherwise, it will save files to a cache at the end of the workflow run.
 
-To restore files from a cache without saving them at the end of the workflow run, refer to the [restore sub-action](https://github.com/threeal/cache-action/tree/v0.3.0/restore).
+To restore and save the cache in separate steps, refer to the [restore](https://github.com/threeal/cache-action/tree/v0.3.0/restore) and [save](https://github.com/threeal/cache-action/tree/v0.3.0/save) sub-actions.
 
 ### Available Inputs
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ export default [
   ...tseslint.configs.recommended,
   ...tseslint.configs.stylistic,
   {
-    ignores: [".*", "dist", "docs", "restore/dist"],
+    ignores: [".*", "dist", "docs", "restore/dist", "save/dist"],
   },
   {
     files: ["**/*.test.ts"],

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "rollup -c",
     "docs": "typedoc src/lib.ts",
-    "format": "prettier --write --cache . !dist !restore/dist",
+    "format": "prettier --write --cache . !dist !restore/dist !save/dist",
     "lint": "eslint",
     "prepack": "rollup -c",
     "test": "jest"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -40,4 +40,12 @@ export default [
     },
     plugins: [nodeResolve(), ts({ transpileOnly: true })],
   },
+  {
+    input: "save/src/main.ts",
+    output: {
+      dir: "save/dist",
+      entryFileNames: "[name].mjs",
+    },
+    plugins: [nodeResolve(), ts({ transpileOnly: true })],
+  },
 ];

--- a/save/README.md
+++ b/save/README.md
@@ -1,0 +1,59 @@
+# Save Cache Action
+
+Use the following snippet to include the action in a GitHub workflow:
+
+```yaml
+- name: Save Dependencies Cache
+  uses: threeal/cache-action/save@v0.3.0
+  with:
+    key: a-key
+    version: a-version
+    files: a-file another-file
+```
+
+By default, the action will save files to a cache if it does not already exist. It will set an output indicating whether the cache was successfully saved.
+
+## Available Inputs
+
+| Name      | Value Type       | Description                                              |
+| --------- | ---------------- | -------------------------------------------------------- |
+| `key`     | String           | The cache key.                                           |
+| `version` | String           | The cache version.                                       |
+| `files`   | Multiple Strings | The files to be cached, separated by spaces or newlines. |
+
+## Available Outputs
+
+| Name    | Value Type        | Description                                                          |
+| ------- | ----------------- | -------------------------------------------------------------------- |
+| `saved` | `true` or `false` | A boolean value indicating whether the cache was successfully saved. |
+
+## Example Usage
+
+The following example demonstrates how to use the action to save [Node.js](https://nodejs.org/) dependencies as a cache in a GitHub Action workflow:
+
+```yaml
+name: Build
+on:
+  push:
+jobs:
+  build-project:
+    name: Build Project
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v4.1.7
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Save Dependencies to Cache
+        uses: threeal/cache-action/save@v0.3.0
+        with:
+          key: node-deps
+          version: ${{ hashFiles('package-lock.json') }}
+          files: node_modules
+
+      # Do something
+```
+
+This action will install the project dependencies and then save the `node_modules` directory to a cache with the `node-deps` key and a version specified by the hash of the `package-lock.json` file.

--- a/save/action.yml
+++ b/save/action.yml
@@ -1,0 +1,22 @@
+name: Save Cache Action
+author: Alfi Maulana
+description: Save files as a cache
+branding:
+  icon: archive
+  color: black
+inputs:
+  key:
+    description: The cache key
+    required: true
+  version:
+    description: The cache version
+    required: true
+  files:
+    description: The files to be cached
+    required: true
+outputs:
+  saved:
+    description: A boolean value indicating whether the cache was successfully saved
+runs:
+  using: node20
+  main: dist/main.mjs

--- a/save/dist/main.mjs
+++ b/save/dist/main.mjs
@@ -1,0 +1,357 @@
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import https from 'node:https';
+import { spawn } from 'node:child_process';
+
+/**
+ * @internal
+ * Retrieves the value of an environment variable.
+ *
+ * @param name - The name of the environment variable.
+ * @returns The value of the environment variable.
+ * @throws Error if the environment variable is not defined.
+ */
+function mustGetEnvironment(name) {
+    const value = process.env[name];
+    if (value === undefined) {
+        throw new Error(`the ${name} environment variable must be defined`);
+    }
+    return value;
+}
+/**
+ * Retrieves the value of a GitHub Actions input.
+ *
+ * @param name - The name of the GitHub Actions input.
+ * @returns The value of the GitHub Actions input, or an empty string if not found.
+ */
+function getInput(name) {
+    const value = process.env[`INPUT_${name.toUpperCase()}`] ?? "";
+    return value.trim();
+}
+/**
+ * Sets the value of a GitHub Actions output.
+ *
+ * @param name - The name of the GitHub Actions output.
+ * @param value - The value to set for the GitHub Actions output.
+ * @returns A promise that resolves when the value is successfully set.
+ */
+async function setOutput(name, value) {
+    const filePath = mustGetEnvironment("GITHUB_OUTPUT");
+    await fsPromises.appendFile(filePath, `${name}=${value}${os.EOL}`);
+}
+
+/**
+ * Logs an information message in GitHub Actions.
+ *
+ * @param message - The information message to log.
+ */
+function logInfo(message) {
+    process.stdout.write(`${message}${os.EOL}`);
+}
+/**
+ * Logs an error message in GitHub Actions.
+ *
+ * @param err - The error, which can be of any type.
+ */
+function logError(err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stdout.write(`::error::${message}${os.EOL}`);
+}
+
+/**
+ * Sends an HTTP request containing raw data.
+ *
+ * @param req - The HTTP request object.
+ * @param data - The raw data to be sent in the request body.
+ * @returns A promise that resolves to an HTTP response object.
+ */
+async function sendRequest(req, data) {
+    return new Promise((resolve, reject) => {
+        req.on("response", (res) => resolve(res));
+        req.on("error", reject);
+        if (data !== undefined)
+            req.write(data);
+        req.end();
+    });
+}
+/**
+ * Sends an HTTP request containing JSON data.
+ *
+ * @param req - The HTTP request object.
+ * @param data - The JSON data to be sent in the request body.
+ * @returns A promise that resolves to an HTTP response object.
+ */
+async function sendJsonRequest(req, data) {
+    req.setHeader("Content-Type", "application/json");
+    return sendRequest(req, JSON.stringify(data));
+}
+/**
+ * Sends an HTTP request containing a binary stream.
+ *
+ * @param req - The HTTP request object.
+ * @param bin - The binary stream to be sent in the request body.
+ * @param start - The starting byte of the binary stream.
+ * @param end - The ending byte of the binary stream.
+ * @returns A promise that resolves to an HTTP response object.
+ */
+async function sendStreamRequest(req, bin, start, end) {
+    return new Promise((resolve, reject) => {
+        req.setHeader("Content-Type", "application/octet-stream");
+        req.setHeader("Content-Range", `bytes ${start}-${end}/*`);
+        req.on("response", (res) => resolve(res));
+        req.on("error", reject);
+        bin.pipe(req);
+    });
+}
+/**
+ * Asserts whether the content type of the given HTTP incoming message matches
+ * the expected type.
+ *
+ * @param msg - The HTTP incoming message.
+ * @param expectedType - The expected content type of the message.
+ * @throws {Error} Throws an error if the content type does not match the
+ * expected type.
+ */
+function assertIncomingMessageContentType(msg, expectedType) {
+    const actualType = msg.headers["content-type"] ?? "undefined";
+    if (!actualType.includes(expectedType)) {
+        throw new Error(`expected content type to be '${expectedType}', but instead got '${actualType}'`);
+    }
+}
+/**
+ * Waits until an HTTP incoming message has ended.
+ *
+ * @param msg - The HTTP incoming message.
+ * @returns A promise that resolves when the incoming message ends.
+ */
+async function waitIncomingMessage(msg) {
+    return new Promise((resolve, reject) => {
+        msg.on("data", () => {
+            /** discarded **/
+        });
+        msg.on("end", resolve);
+        msg.on("error", reject);
+    });
+}
+/**
+ * Reads the data from an HTTP incoming message.
+ *
+ * @param msg - The HTTP incoming message.
+ * @returns A promise that resolves to the buffered data from the message.
+ */
+async function readIncomingMessage(msg) {
+    return new Promise((resolve, reject) => {
+        const chunks = [];
+        msg.on("data", (chunk) => chunks.push(chunk));
+        msg.on("end", () => resolve(Buffer.concat(chunks)));
+        msg.on("error", reject);
+    });
+}
+/**
+ * Reads the JSON data from an HTTP incoming message.
+ *
+ * @typeParam T - The expected type of the parsed JSON data.
+ * @param msg - The HTTP incoming message.
+ * @returns A promise that resolves to the parsed JSON data from the message.
+ */
+async function readJsonIncomingMessage(msg) {
+    assertIncomingMessageContentType(msg, "application/json");
+    const buffer = await readIncomingMessage(msg);
+    return JSON.parse(buffer.toString());
+}
+/**
+ * Reads the error data from an HTTP incoming message.
+ *
+ * @param msg - The HTTP incoming message.
+ * @returns A promise that resolves to an `Error` object based on the error
+ * data from the message.
+ */
+async function readErrorIncomingMessage(msg) {
+    const buffer = await readIncomingMessage(msg);
+    const contentType = msg.headers["content-type"];
+    if (contentType !== undefined) {
+        if (contentType.includes("application/json")) {
+            const data = JSON.parse(buffer.toString());
+            if (typeof data === "object" && "message" in data) {
+                return new Error(`${data["message"]} (${msg.statusCode})`);
+            }
+        }
+        else if (contentType.includes("application/xml")) {
+            const data = buffer.toString().match(/<Message>(.*?)<\/Message>/s);
+            if (data !== null && data.length > 1) {
+                return new Error(`${data[1]} (${msg.statusCode})`);
+            }
+        }
+    }
+    return new Error(`${buffer.toString()} (${msg.statusCode})`);
+}
+
+function createCacheRequest(resourcePath, options) {
+    const url = `${process.env["ACTIONS_CACHE_URL"]}_apis/artifactcache/${resourcePath}`;
+    const req = https.request(url, options);
+    req.setHeader("Accept", "application/json;api-version=6.0-preview");
+    const bearer = `Bearer ${process.env["ACTIONS_RUNTIME_TOKEN"]}`;
+    req.setHeader("Authorization", bearer);
+    return req;
+}
+/**
+ * Sends a request to reserve a cache with the specified key, version, and size.
+ *
+ * @param key - The key of the cache to reserve.
+ * @param version - The version of the cache to reserve.
+ * @param size - The size of the cache to reserve, in bytes.
+ * @returns A promise that resolves to the reserved cache ID, or null if the
+ * cache is already reserved.
+ */
+async function requestReserveCache(key, version, size) {
+    const req = createCacheRequest("caches", { method: "POST" });
+    const res = await sendJsonRequest(req, { key, version, cacheSize: size });
+    switch (res.statusCode) {
+        case 201: {
+            const { cacheId } = await readJsonIncomingMessage(res);
+            return cacheId;
+        }
+        // Cache already reserved, return null.
+        case 409:
+            await waitIncomingMessage(res);
+            return null;
+        default:
+            throw await readErrorIncomingMessage(res);
+    }
+}
+/**
+ * Sends multiple requests to upload a file to the cache with the specified ID.
+ *
+ * @param id - The cache ID.
+ * @param filePath - The path of the file to upload.
+ * @param fileSize - The size of the file to upload, in bytes.
+ * @param options - The upload options.
+ * @param options.maxChunkSize - The maximum size of each chunk to be uploaded,
+ * in bytes. Defaults to 4 MB.
+ * @returns A promise that resolves when the file has been uploaded.
+ */
+async function requestUploadCache(id, filePath, fileSize, options) {
+    const { maxChunkSize } = {
+        maxChunkSize: 4 * 1024 * 1024,
+        ...options,
+    };
+    const proms = [];
+    for (let start = 0; start < fileSize; start += maxChunkSize) {
+        proms.push((async () => {
+            const end = Math.min(start + maxChunkSize - 1, fileSize);
+            const bin = fs.createReadStream(filePath, { start, end });
+            const req = createCacheRequest(`caches/${id}`, { method: "PATCH" });
+            const res = await sendStreamRequest(req, bin, start, end);
+            switch (res.statusCode) {
+                case 204:
+                    await waitIncomingMessage(res);
+                    break;
+                default:
+                    throw await readErrorIncomingMessage(res);
+            }
+        })());
+    }
+    await Promise.all(proms);
+}
+/**
+ * Sends a request to commit a cache with the specified ID.
+ *
+ * @param id - The cache ID.
+ * @param size - The size of the cache to be committed, in bytes.
+ * @returns A promise that resolves when the cache has been committed.
+ */
+async function requestCommitCache(id, size) {
+    const req = createCacheRequest(`caches/${id}`, { method: "POST" });
+    const res = await sendJsonRequest(req, { size });
+    if (res.statusCode !== 204) {
+        throw await readErrorIncomingMessage(res);
+    }
+    await waitIncomingMessage(res);
+}
+
+/**
+ * Waits for a child process to exit.
+ *
+ * @param proc - The child process to wait for.
+ * @returns A promise that resolves when the child process exits successfully,
+ * or rejects if the process fails.
+ */
+async function waitChildProcess(proc) {
+    return new Promise((resolve, reject) => {
+        const chunks = [];
+        proc.stderr?.on("data", (chunk) => chunks.push(chunk));
+        proc.on("error", reject);
+        proc.on("close", (code) => {
+            if (code === 0) {
+                resolve(undefined);
+            }
+            else {
+                reject(new Error([
+                    `Process failed: ${proc.spawnargs.join(" ")}`,
+                    Buffer.concat(chunks).toString(),
+                ].join("\n")));
+            }
+        });
+    });
+}
+/**
+ * Creates a compressed archive from files using Tar and Zstandard.
+ *
+ * @param archivePath - The output path for the compressed archive.
+ * @param filePaths - The paths of the files to be archived.
+ * @returns A promise that resolves when the compressed archive is created.
+ */
+async function createArchive(archivePath, filePaths) {
+    const tar = spawn("tar", ["-cf", "-", "-P", ...filePaths]);
+    const zstd = spawn("zstd", ["-T0", "-o", archivePath]);
+    tar.stdout.pipe(zstd.stdin);
+    await Promise.all([waitChildProcess(tar), waitChildProcess(zstd)]);
+}
+
+/**
+ * Saves files to the cache using the specified key and version.
+ *
+ * @param key - The cache key.
+ * @param version - The cache version.
+ * @param filePaths - The paths of the files to be saved.
+ * @returns A promise that resolves to a boolean value indicating whether the
+ * file was saved successfully.
+ */
+async function saveCache(key, version, filePaths) {
+    const tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "temp-"));
+    const archivePath = path.join(tempDir, "cache.tar.zst");
+    await createArchive(archivePath, filePaths);
+    const archiveStat = await fsPromises.stat(archivePath);
+    const cacheId = await requestReserveCache(key, version, archiveStat.size);
+    if (cacheId === null) {
+        await fsPromises.rm(tempDir, { recursive: true });
+        return false;
+    }
+    await requestUploadCache(cacheId, archivePath, archiveStat.size);
+    await requestCommitCache(cacheId, archiveStat.size);
+    await fsPromises.rm(tempDir, { recursive: true });
+    return true;
+}
+
+try {
+    const key = getInput("key");
+    const version = getInput("version");
+    const filePaths = getInput("files")
+        .split(/\s+/)
+        .filter((arg) => arg != "");
+    logInfo("Saving cache...");
+    if (await saveCache(key, version, filePaths)) {
+        logInfo("Cache successfully saved");
+        await setOutput("saved", "true");
+    }
+    else {
+        logInfo("Aborting cache save, cache already exists");
+        await setOutput("saved", "false");
+    }
+}
+catch (err) {
+    logError(err);
+    process.exit(1);
+}

--- a/save/src/main.ts
+++ b/save/src/main.ts
@@ -1,0 +1,22 @@
+import { getInput, logError, logInfo, setOutput } from "gha-utils";
+import { saveCache } from "../../src/lib.js";
+
+try {
+  const key = getInput("key");
+  const version = getInput("version");
+  const filePaths = getInput("files")
+    .split(/\s+/)
+    .filter((arg) => arg != "");
+
+  logInfo("Saving cache...");
+  if (await saveCache(key, version, filePaths)) {
+    logInfo("Cache successfully saved");
+    await setOutput("saved", "true");
+  } else {
+    logInfo("Aborting cache save, cache already exists");
+    await setOutput("saved", "false");
+  }
+} catch (err) {
+  logError(err);
+  process.exit(1);
+}


### PR DESCRIPTION
This pull request resolves #173 by adding a new `save` sub-action for saving files to a cache at a specific step in a workflow run. It also updates the `test` workflow to include tests for the sub-action and modifies the `README.md` file to include usage examples of the sub-action.