### PR TITLE
Handle Case When Incoming Error Message Is Empty

### DIFF
--- a/dist/main.mjs
+++ b/dist/main.mjs
@@ -166,7 +166,8 @@ async function readErrorIncomingMessage(msg) {
             }
         }
     }
-    return new Error(`${buffer.toString()} (${msg.statusCode})`);
+    const err = buffer.byteLength > 0 ? buffer.toString() : "unknown error";
+    return new Error(`${err} (${msg.statusCode})`);
 }
 
 function createCacheRequest(resourcePath, options) {

--- a/dist/post.mjs
+++ b/dist/post.mjs
@@ -169,7 +169,8 @@ async function readErrorIncomingMessage(msg) {
             }
         }
     }
-    return new Error(`${buffer.toString()} (${msg.statusCode})`);
+    const err = buffer.byteLength > 0 ? buffer.toString() : "unknown error";
+    return new Error(`${err} (${msg.statusCode})`);
 }
 
 function createCacheRequest(resourcePath, options) {

--- a/restore/dist/main.mjs
+++ b/restore/dist/main.mjs
@@ -154,7 +154,8 @@ async function readErrorIncomingMessage(msg) {
             }
         }
     }
-    return new Error(`${buffer.toString()} (${msg.statusCode})`);
+    const err = buffer.byteLength > 0 ? buffer.toString() : "unknown error";
+    return new Error(`${err} (${msg.statusCode})`);
 }
 
 function createCacheRequest(resourcePath, options) {

--- a/save/dist/main.mjs
+++ b/save/dist/main.mjs
@@ -185,7 +185,8 @@ async function readErrorIncomingMessage(msg) {
             }
         }
     }
-    return new Error(`${buffer.toString()} (${msg.statusCode})`);
+    const err = buffer.byteLength > 0 ? buffer.toString() : "unknown error";
+    return new Error(`${err} (${msg.statusCode})`);
 }
 
 function createCacheRequest(resourcePath, options) {

--- a/src/utils/http.test.ts
+++ b/src/utils/http.test.ts
@@ -101,6 +101,22 @@ describe("echo HTTP requests", () => {
   });
 
   describe("echo error data", () => {
+    it("should echo empty error data", async () => {
+      const { readErrorIncomingMessage, sendRequest } = await import(
+        "./http.js"
+      );
+
+      const req = http.request("http://localhost:10001/echo-error", {
+        method: "POST",
+      });
+
+      const res = await sendRequest(req);
+      expect(res.statusCode).toBe(500);
+
+      const err = await readErrorIncomingMessage(res);
+      expect(err).toEqual(new Error("unknown error (500)"));
+    });
+
     it("should echo error data in JSON", async () => {
       const { readErrorIncomingMessage, sendJsonRequest } = await import(
         "./http.js"

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -160,5 +160,6 @@ export async function readErrorIncomingMessage(
     }
   }
 
-  return new Error(`${buffer.toString()} (${msg.statusCode})`);
+  const err = buffer.byteLength > 0 ? buffer.toString() : "unknown error";
+  return new Error(`${err} (${msg.statusCode})`);
 }


### PR DESCRIPTION
This pull request resolves #175 by modifying the `readErrorIncomingMessage` function to handle empty error messages. It also updates the tests accordingly.