### PR TITLE
Remove Files Input in Restore Sub-Action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -127,9 +127,6 @@ jobs:
         with:
           key: another-key-${{ matrix.os }}
           version: ${{ github.run_id }}
-          files: |
-            a-file another-file
-            a-dir/a-file
 
       - name: Check Output
         shell: bash
@@ -170,9 +167,6 @@ jobs:
         with:
           key: another-key-${{ matrix.os }}
           version: ${{ github.run_id }}
-          files: |
-            a-file another-file
-            a-dir/a-file
 
       - name: Check Output
         shell: bash

--- a/restore/README.md
+++ b/restore/README.md
@@ -8,18 +8,16 @@ Use the following snippet to include the action in a GitHub workflow:
   with:
     key: a-key
     version: a-version
-    files: a-file another-file
 ```
 
 By default, the action will attempt to restore files from a cache if it exists. It will set an output that indicates whether the cache was successfully restored.
 
 ## Available Inputs
 
-| Name      | Value Type       | Description                                              |
-| --------- | ---------------- | -------------------------------------------------------- |
-| `key`     | String           | The cache key.                                           |
-| `version` | String           | The cache version.                                       |
-| `files`   | Multiple Strings | The files to be cached, separated by spaces or newlines. |
+| Name      | Value Type | Description        |
+| --------- | ---------- | ------------------ |
+| `key`     | String     | The cache key.     |
+| `version` | String     | The cache version. |
 
 ## Available Outputs
 
@@ -49,7 +47,6 @@ jobs:
         with:
           key: node-deps
           version: ${{ hashFiles('package-lock.json') }}
-          files: node_modules
 
       - name: Install Dependencies
         if: steps.restore-deps-cache.outputs.restored == 'false'

--- a/restore/action.yml
+++ b/restore/action.yml
@@ -11,9 +11,6 @@ inputs:
   version:
     description: The cache version
     required: true
-  files:
-    description: The files to be cached
-    required: true
 outputs:
   restored:
     description: A boolean value indicating whether the cache was successfully restored


### PR DESCRIPTION
This pull request resolves #179 by removing the unused `files` input from the `restore` sub-action.