### PR TITLE
Remove Upload Artifact Steps in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,14 +21,6 @@ jobs:
       - name: Build Package
         run: pnpm pack --out package.tgz
 
-      - name: Upload Package
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          name: package
-          path: package.tgz
-          if-no-files-found: error
-          overwrite: true
-
   build-docs:
     name: Build Documentation
     runs-on: ubuntu-24.04
@@ -44,11 +36,3 @@ jobs:
 
       - name: Build Documentation
         run: pnpm typedoc src/lib.ts
-
-      - name: Upload Documentation
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          name: docs
-          path: docs
-          if-no-files-found: error
-          overwrite: true


### PR DESCRIPTION
This pull request resolves #462 by removing the upload artifact steps from the Build workflow.