### PR TITLE
Remove Unnecessary Vitest Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "prepack": "tsc -p tsconfig.build.json",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-  test: {
-    watch: false,
-  },
-});


### PR DESCRIPTION
This pull request resolves #469 by removing the unnecessary `vitest.config.ts` file.