### PR TITLE
Strict TypeScript ESLint configuration

### DIFF
--- a/dist/action/main.bundle.mjs
+++ b/dist/action/main.bundle.mjs
@@ -73,24 +73,26 @@ function logError(err) {
 }
 
 async function fetchCacheService(method, body) {
-    return fetch(`${process.env["ACTIONS_RESULTS_URL"]}twirp/github.actions.results.api.v1.CacheService/${method}`, {
+    const url = process.env.ACTIONS_RESULTS_URL ?? "/";
+    const token = process.env.ACTIONS_RUNTIME_TOKEN ?? "";
+    return fetch(`${url}twirp/github.actions.results.api.v1.CacheService/${method}`, {
         body: JSON.stringify(body),
         method: "POST",
         headers: {
-            Authorization: `Bearer ${process.env["ACTIONS_RUNTIME_TOKEN"]}`,
+            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
         },
     });
 }
 async function handleCacheServiceError(res) {
     const contentType = res.headers.get("content-type");
-    if (contentType && contentType.includes("application/json")) {
+    if (contentType?.includes("application/json")) {
         const data = await res.json();
         if (typeof data === "object" && data && "msg" in data) {
-            return new Error(`${data["msg"]} (${res.status})`);
+            return new Error(`${data.msg} (${res.status.toFixed()})`);
         }
     }
-    throw new Error(`${res.statusText} (${res.status})`);
+    throw new Error(`${res.statusText} (${res.status.toFixed()})`);
 }
 function hashVersion(version) {
     return createHash("sha256").update(version).digest("hex");

--- a/dist/action/post.bundle.mjs
+++ b/dist/action/post.bundle.mjs
@@ -45,24 +45,26 @@ function logError(err) {
 }
 
 async function fetchCacheService(method, body) {
-    return fetch(`${process.env["ACTIONS_RESULTS_URL"]}twirp/github.actions.results.api.v1.CacheService/${method}`, {
+    const url = process.env.ACTIONS_RESULTS_URL ?? "/";
+    const token = process.env.ACTIONS_RUNTIME_TOKEN ?? "";
+    return fetch(`${url}twirp/github.actions.results.api.v1.CacheService/${method}`, {
         body: JSON.stringify(body),
         method: "POST",
         headers: {
-            Authorization: `Bearer ${process.env["ACTIONS_RUNTIME_TOKEN"]}`,
+            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
         },
     });
 }
 async function handleCacheServiceError(res) {
     const contentType = res.headers.get("content-type");
-    if (contentType && contentType.includes("application/json")) {
+    if (contentType?.includes("application/json")) {
         const data = await res.json();
         if (typeof data === "object" && data && "msg" in data) {
-            return new Error(`${data["msg"]} (${res.status})`);
+            return new Error(`${data.msg} (${res.status.toFixed()})`);
         }
     }
-    throw new Error(`${res.statusText} (${res.status})`);
+    throw new Error(`${res.statusText} (${res.status.toFixed()})`);
 }
 function hashVersion(version) {
     return createHash("sha256").update(version).digest("hex");

--- a/dist/action/restore.bundle.mjs
+++ b/dist/action/restore.bundle.mjs
@@ -61,24 +61,26 @@ function logError(err) {
 }
 
 async function fetchCacheService(method, body) {
-    return fetch(`${process.env["ACTIONS_RESULTS_URL"]}twirp/github.actions.results.api.v1.CacheService/${method}`, {
+    const url = process.env.ACTIONS_RESULTS_URL ?? "/";
+    const token = process.env.ACTIONS_RUNTIME_TOKEN ?? "";
+    return fetch(`${url}twirp/github.actions.results.api.v1.CacheService/${method}`, {
         body: JSON.stringify(body),
         method: "POST",
         headers: {
-            Authorization: `Bearer ${process.env["ACTIONS_RUNTIME_TOKEN"]}`,
+            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
         },
     });
 }
 async function handleCacheServiceError(res) {
     const contentType = res.headers.get("content-type");
-    if (contentType && contentType.includes("application/json")) {
+    if (contentType?.includes("application/json")) {
         const data = await res.json();
         if (typeof data === "object" && data && "msg" in data) {
-            return new Error(`${data["msg"]} (${res.status})`);
+            return new Error(`${data.msg} (${res.status.toFixed()})`);
         }
     }
-    throw new Error(`${res.statusText} (${res.status})`);
+    throw new Error(`${res.statusText} (${res.status.toFixed()})`);
 }
 function hashVersion(version) {
     return createHash("sha256").update(version).digest("hex");

--- a/dist/action/save.bundle.mjs
+++ b/dist/action/save.bundle.mjs
@@ -61,24 +61,26 @@ function logError(err) {
 }
 
 async function fetchCacheService(method, body) {
-    return fetch(`${process.env["ACTIONS_RESULTS_URL"]}twirp/github.actions.results.api.v1.CacheService/${method}`, {
+    const url = process.env.ACTIONS_RESULTS_URL ?? "/";
+    const token = process.env.ACTIONS_RUNTIME_TOKEN ?? "";
+    return fetch(`${url}twirp/github.actions.results.api.v1.CacheService/${method}`, {
         body: JSON.stringify(body),
         method: "POST",
         headers: {
-            Authorization: `Bearer ${process.env["ACTIONS_RUNTIME_TOKEN"]}`,
+            Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
         },
     });
 }
 async function handleCacheServiceError(res) {
     const contentType = res.headers.get("content-type");
-    if (contentType && contentType.includes("application/json")) {
+    if (contentType?.includes("application/json")) {
         const data = await res.json();
         if (typeof data === "object" && data && "msg" in data) {
-            return new Error(`${data["msg"]} (${res.status})`);
+            return new Error(`${data.msg} (${res.status.toFixed()})`);
         }
     }
-    throw new Error(`${res.statusText} (${res.status})`);
+    throw new Error(`${res.statusText} (${res.status.toFixed()})`);
 }
 function hashVersion(version) {
     return createHash("sha256").update(version).digest("hex");

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,18 +1,20 @@
 import eslint from "@eslint/js";
+import { globalIgnores } from "eslint/config";
 import tseslint from "typescript-eslint";
 
-export default [
+export default tseslint.config(
+  globalIgnores(["dist", "docs"]),
   eslint.configs.recommended,
-  ...tseslint.configs.recommended,
-  ...tseslint.configs.stylistic,
+  tseslint.configs.strictTypeChecked,
+  tseslint.configs.stylisticTypeChecked,
   {
-    ignores: [".*", "dist", "docs"],
-  },
-  {
-    files: ["**/*.test.ts"],
-    rules: {
-      "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-empty-object-type": "off",
+    languageOptions: {
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ["eslint.config.js", "rollup.config.js"],
+        },
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
   },
-];
+);

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -11,7 +11,7 @@ export default tseslint.config(
     languageOptions: {
       parserOptions: {
         projectService: {
-          allowDefaultProject: ["eslint.config.js", "rollup.config.js"],
+          allowDefaultProject: ["rollup.config.js"],
         },
         tsconfigRootDir: import.meta.dirname,
       },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/node": "^24.0.1",
     "eslint": "^9.29.0",
     "gha-utils": "^0.4.1",
+    "jiti": "^2.4.2",
     "lefthook": "^1.11.13",
     "prettier": "^3.5.3",
     "rollup": "^4.40.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,10 +25,13 @@ importers:
         version: 24.0.1
       eslint:
         specifier: ^9.29.0
-        version: 9.29.0
+        version: 9.29.0(jiti@2.4.2)
       gha-utils:
         specifier: ^0.4.1
         version: 0.4.1
+      jiti:
+        specifier: ^2.4.2
+        version: 2.4.2
       lefthook:
         specifier: ^1.11.13
         version: 1.11.13
@@ -49,10 +52,10 @@ importers:
         version: 5.8.3
       typescript-eslint:
         specifier: ^8.34.1
-        version: 8.34.1(eslint@9.29.0)(typescript@5.8.3)
+        version: 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
       vitest:
         specifier: ^3.2.3
-        version: 3.2.3(@types/node@24.0.1)(yaml@2.8.0)
+        version: 3.2.3(@types/node@24.0.1)(jiti@2.4.2)(yaml@2.8.0)
 
 packages:
 
@@ -824,6 +827,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  jiti@2.4.2:
+    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+    hasBin: true
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
@@ -1324,9 +1331,9 @@ snapshots:
   '@esbuild/win32-x64@0.25.5':
     optional: true
 
-  '@eslint-community/eslint-utils@4.7.0(eslint@9.29.0)':
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.29.0(jiti@2.4.2))':
     dependencies:
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -1540,15 +1547,15 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.34.1
-      '@typescript-eslint/type-utils': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.34.1
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -1557,14 +1564,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.34.1(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.34.1
       '@typescript-eslint/types': 8.34.1
       '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.34.1
       debug: 4.4.1
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -1587,12 +1594,12 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  '@typescript-eslint/type-utils@8.34.1(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
       debug: 4.4.1
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -1616,13 +1623,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.34.1(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.34.1
       '@typescript-eslint/types': 8.34.1
       '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.8.3)
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -1640,13 +1647,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.3(vite@6.3.5(@types/node@24.0.1)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.3(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.3
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@24.0.1)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.1)(jiti@2.4.2)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.3':
     dependencies:
@@ -1796,9 +1803,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.29.0:
+  eslint@9.29.0(jiti@2.4.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@2.4.2))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.20.1
       '@eslint/config-helpers': 0.2.3
@@ -1833,6 +1840,8 @@ snapshots:
       minimatch: 3.1.2
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -1955,6 +1964,8 @@ snapshots:
   is-number@7.0.0: {}
 
   isexe@2.0.0: {}
+
+  jiti@2.4.2: {}
 
   js-tokens@9.0.1: {}
 
@@ -2229,12 +2240,12 @@ snapshots:
       typescript: 5.8.3
       yaml: 2.8.0
 
-  typescript-eslint@8.34.1(eslint@9.29.0)(typescript@5.8.3):
+  typescript-eslint@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.8.3)
-      eslint: 9.29.0
+      '@typescript-eslint/eslint-plugin': 8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
+      eslint: 9.29.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -2249,13 +2260,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@3.2.3(@types/node@24.0.1)(yaml@2.8.0):
+  vite-node@3.2.3(@types/node@24.0.1)(jiti@2.4.2)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@24.0.1)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.1)(jiti@2.4.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2270,7 +2281,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.5(@types/node@24.0.1)(yaml@2.8.0):
+  vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.6(picomatch@4.0.2)
@@ -2281,13 +2292,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.0.1
       fsevents: 2.3.3
+      jiti: 2.4.2
       yaml: 2.8.0
 
-  vitest@3.2.3(@types/node@24.0.1)(yaml@2.8.0):
+  vitest@3.2.3(@types/node@24.0.1)(jiti@2.4.2)(yaml@2.8.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.3
-      '@vitest/mocker': 3.2.3(vite@6.3.5(@types/node@24.0.1)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.3(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.3
       '@vitest/runner': 3.2.3
       '@vitest/snapshot': 3.2.3
@@ -2305,8 +2317,8 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.0
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@24.0.1)(yaml@2.8.0)
-      vite-node: 3.2.3(@types/node@24.0.1)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.1)(jiti@2.4.2)(yaml@2.8.0)
+      vite-node: 3.2.3(@types/node@24.0.1)(jiti@2.4.2)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.0.1

--- a/src/lib/internal/api.ts
+++ b/src/lib/internal/api.ts
@@ -1,13 +1,18 @@
 import { createHash } from "node:crypto";
 
-async function fetchCacheService(method: string, body: unknown) {
+async function fetchCacheService(
+  method: string,
+  body: unknown,
+): Promise<Response> {
+  const url = process.env.ACTIONS_RESULTS_URL ?? "/";
+  const token = process.env.ACTIONS_RUNTIME_TOKEN ?? "";
   return fetch(
-    `${process.env["ACTIONS_RESULTS_URL"]}twirp/github.actions.results.api.v1.CacheService/${method}`,
+    `${url}twirp/github.actions.results.api.v1.CacheService/${method}`,
     {
       body: JSON.stringify(body),
       method: "POST",
       headers: {
-        Authorization: `Bearer ${process.env["ACTIONS_RUNTIME_TOKEN"]}`,
+        Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
       },
     },
@@ -16,13 +21,13 @@ async function fetchCacheService(method: string, body: unknown) {
 
 async function handleCacheServiceError(res: Response) {
   const contentType = res.headers.get("content-type");
-  if (contentType && contentType.includes("application/json")) {
+  if (contentType?.includes("application/json")) {
     const data = await res.json();
     if (typeof data === "object" && data && "msg" in data) {
-      return new Error(`${data["msg"]} (${res.status})`);
+      return new Error(`${data.msg as string} (${res.status.toFixed()})`);
     }
   }
-  throw new Error(`${res.statusText} (${res.status})`);
+  throw new Error(`${res.statusText} (${res.status.toFixed()})`);
 }
 
 function hashVersion(version: string) {

--- a/src/lib/internal/cmd.ts
+++ b/src/lib/internal/cmd.ts
@@ -21,7 +21,7 @@ export async function waitProcess(
 ): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const chunks: Uint8Array[] = [];
-    proc.stderr.on("data", (chunk) => chunks.push(chunk));
+    proc.stderr.on("data", (chunk: Buffer) => chunks.push(chunk));
 
     proc.on("error", reject);
     proc.on("close", (code) => {


### PR DESCRIPTION
This pull request resolves #475 by enabling a stricter TypeScript configuration. This change also convert the ESLint configuration to TypeScript.