### PR TITLE
Fix Error Handler Not Throwing Error

### DIFF
--- a/dist/action/main.bundle.mjs
+++ b/dist/action/main.bundle.mjs
@@ -89,7 +89,7 @@ async function handleCacheServiceError(res) {
     if (contentType?.includes("application/json")) {
         const data = await res.json();
         if (typeof data === "object" && data && "msg" in data) {
-            return new Error(`${data.msg} (${res.status.toFixed()})`);
+            throw new Error(`${data.msg} (${res.status.toFixed()})`);
         }
     }
     throw new Error(`${res.statusText} (${res.status.toFixed()})`);

--- a/dist/action/post.bundle.mjs
+++ b/dist/action/post.bundle.mjs
@@ -61,7 +61,7 @@ async function handleCacheServiceError(res) {
     if (contentType?.includes("application/json")) {
         const data = await res.json();
         if (typeof data === "object" && data && "msg" in data) {
-            return new Error(`${data.msg} (${res.status.toFixed()})`);
+            throw new Error(`${data.msg} (${res.status.toFixed()})`);
         }
     }
     throw new Error(`${res.statusText} (${res.status.toFixed()})`);

--- a/dist/action/restore.bundle.mjs
+++ b/dist/action/restore.bundle.mjs
@@ -77,7 +77,7 @@ async function handleCacheServiceError(res) {
     if (contentType?.includes("application/json")) {
         const data = await res.json();
         if (typeof data === "object" && data && "msg" in data) {
-            return new Error(`${data.msg} (${res.status.toFixed()})`);
+            throw new Error(`${data.msg} (${res.status.toFixed()})`);
         }
     }
     throw new Error(`${res.statusText} (${res.status.toFixed()})`);

--- a/dist/action/save.bundle.mjs
+++ b/dist/action/save.bundle.mjs
@@ -77,7 +77,7 @@ async function handleCacheServiceError(res) {
     if (contentType?.includes("application/json")) {
         const data = await res.json();
         if (typeof data === "object" && data && "msg" in data) {
-            return new Error(`${data.msg} (${res.status.toFixed()})`);
+            throw new Error(`${data.msg} (${res.status.toFixed()})`);
         }
     }
     throw new Error(`${res.statusText} (${res.status.toFixed()})`);

--- a/src/lib/internal/api.ts
+++ b/src/lib/internal/api.ts
@@ -19,12 +19,12 @@ async function fetchCacheService(
   );
 }
 
-async function handleCacheServiceError(res: Response) {
+async function handleCacheServiceError(res: Response): Promise<void> {
   const contentType = res.headers.get("content-type");
   if (contentType?.includes("application/json")) {
     const data = await res.json();
     if (typeof data === "object" && data && "msg" in data) {
-      return new Error(`${data.msg as string} (${res.status.toFixed()})`);
+      throw new Error(`${data.msg as string} (${res.status.toFixed()})`);
     }
   }
   throw new Error(`${res.statusText} (${res.status.toFixed()})`);


### PR DESCRIPTION
This pull request resolves #483 by fixing the `handleCacheServiceError` to properly throw an error.