### PR TITLE
Hash Version in Public Functions

### DIFF
--- a/dist/action/main.bundle.mjs
+++ b/dist/action/main.bundle.mjs
@@ -94,13 +94,10 @@ async function handleCacheServiceError(res) {
     }
     throw new Error(`${res.statusText} (${res.status.toFixed()})`);
 }
-function hashVersion(version) {
-    return createHash("sha256").update(version).digest("hex");
-}
 async function getCacheEntryDownloadUrl(key, version) {
     const res = await fetchCacheService("GetCacheEntryDownloadURL", {
         key,
-        version: hashVersion(version),
+        version,
     });
     if (!res.ok) {
         await handleCacheServiceError(res);
@@ -165,7 +162,8 @@ async function azureStorageCopy(source, destination) {
  * file was restored successfully.
  */
 async function restoreCache(key, version) {
-    const res = await getCacheEntryDownloadUrl(key, version);
+    const versionHash = createHash("sha256").update(version).digest("hex");
+    const res = await getCacheEntryDownloadUrl(key, versionHash);
     if (!res.ok)
         return false;
     const tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "temp-"));

--- a/dist/action/restore.bundle.mjs
+++ b/dist/action/restore.bundle.mjs
@@ -82,13 +82,10 @@ async function handleCacheServiceError(res) {
     }
     throw new Error(`${res.statusText} (${res.status.toFixed()})`);
 }
-function hashVersion(version) {
-    return createHash("sha256").update(version).digest("hex");
-}
 async function getCacheEntryDownloadUrl(key, version) {
     const res = await fetchCacheService("GetCacheEntryDownloadURL", {
         key,
-        version: hashVersion(version),
+        version,
     });
     if (!res.ok) {
         await handleCacheServiceError(res);
@@ -153,7 +150,8 @@ async function azureStorageCopy(source, destination) {
  * file was restored successfully.
  */
 async function restoreCache(key, version) {
-    const res = await getCacheEntryDownloadUrl(key, version);
+    const versionHash = createHash("sha256").update(version).digest("hex");
+    const res = await getCacheEntryDownloadUrl(key, versionHash);
     if (!res.ok)
         return false;
     const tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "temp-"));

--- a/dist/action/save.bundle.mjs
+++ b/dist/action/save.bundle.mjs
@@ -82,13 +82,10 @@ async function handleCacheServiceError(res) {
     }
     throw new Error(`${res.statusText} (${res.status.toFixed()})`);
 }
-function hashVersion(version) {
-    return createHash("sha256").update(version).digest("hex");
-}
 async function createCacheEntry(key, version) {
     const res = await fetchCacheService("CreateCacheEntry", {
         key,
-        version: hashVersion(version),
+        version,
     });
     if (!res.ok) {
         if (res.status == 409)
@@ -100,7 +97,7 @@ async function createCacheEntry(key, version) {
 async function finalizeCacheEntryUpload(key, version, sizeBytes) {
     const res = await fetchCacheService("FinalizeCacheEntryUpload", {
         key,
-        version: hashVersion(version),
+        version,
         sizeBytes,
     });
     if (!res.ok) {
@@ -171,10 +168,11 @@ async function saveCache(key, version, filePaths) {
     const archivePath = path.join(tempDir, "cache.tar.zst");
     await createArchive(archivePath, filePaths);
     const archiveStat = await fsPromises.stat(archivePath);
-    const res = await createCacheEntry(key, version);
+    const versionHash = createHash("sha256").update(version).digest("hex");
+    const res = await createCacheEntry(key, versionHash);
     if (res.ok) {
         await azureStorageCopy(archivePath, res.signed_upload_url);
-        const { ok } = await finalizeCacheEntryUpload(key, version, archiveStat.size);
+        const { ok } = await finalizeCacheEntryUpload(key, versionHash, archiveStat.size);
         res.ok = ok;
     }
     await fsPromises.rm(tempDir, { recursive: true });

--- a/src/lib/internal/api.ts
+++ b/src/lib/internal/api.ts
@@ -1,5 +1,3 @@
-import { createHash } from "node:crypto";
-
 async function fetchCacheService(
   method: string,
   body: unknown,
@@ -30,10 +28,6 @@ async function handleCacheServiceError(res: Response) {
   throw new Error(`${res.statusText} (${res.status.toFixed()})`);
 }
 
-function hashVersion(version: string) {
-  return createHash("sha256").update(version).digest("hex");
-}
-
 interface GetCacheEntryDownloadUrlResponseSchema {
   ok: boolean;
   signed_download_url: string;
@@ -45,7 +39,7 @@ export async function getCacheEntryDownloadUrl(
 ): Promise<GetCacheEntryDownloadUrlResponseSchema> {
   const res = await fetchCacheService("GetCacheEntryDownloadURL", {
     key,
-    version: hashVersion(version),
+    version,
   });
   if (!res.ok) {
     await handleCacheServiceError(res);
@@ -64,7 +58,7 @@ export async function createCacheEntry(
 ): Promise<CreateCacheEntryResponse> {
   const res = await fetchCacheService("CreateCacheEntry", {
     key,
-    version: hashVersion(version),
+    version,
   });
   if (!res.ok) {
     if (res.status == 409) return { ok: false, signed_upload_url: "" };
@@ -85,7 +79,7 @@ export async function finalizeCacheEntryUpload(
 ): Promise<FinalizeCacheEntryUploadResponse> {
   const res = await fetchCacheService("FinalizeCacheEntryUpload", {
     key,
-    version: hashVersion(version),
+    version,
     sizeBytes,
   });
   if (!res.ok) {


### PR DESCRIPTION
This pull request resolves #485 by hashing the version in the `restoreCache` and `saveCache` functions instead in the internal functions, minimize the call needed to hash the version.