### PR TITLE
Remove tslib From Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "lefthook": "^1.11.14",
     "prettier": "^3.5.3",
     "rollup": "^4.43.0",
-    "tslib": "^2.8.1",
     "typedoc": "^0.28.5",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.34.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       rollup:
         specifier: ^4.43.0
         version: 4.43.0
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
       typedoc:
         specifier: ^0.28.5
         version: 0.28.5(typescript@5.8.3)
@@ -2225,7 +2222,8 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  tslib@2.8.1: {}
+  tslib@2.8.1:
+    optional: true
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
This pull request resolves #728 by removing the unused tslib package from the dependencies in this project.