### PR TITLE
Replace `tseslint.config` with `defineConfig`

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,8 +1,8 @@
 import eslint from "@eslint/js";
-import { globalIgnores } from "eslint/config";
+import { defineConfig, globalIgnores } from "eslint/config";
 import tseslint from "typescript-eslint";
 
-export default tseslint.config(
+export default defineConfig(
   globalIgnores(["dist", "docs"]),
   eslint.configs.recommended,
   tseslint.configs.strictTypeChecked,


### PR DESCRIPTION
This pull request resolves #560 by replacing `tseslint.config` with `defineConfig`.