### PR TITLE
Bump Node to version 24.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": "^24.16.0",
+      "version": "^24.17.0",
       "onFail": "download"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2
       node:
-        specifier: runtime:^24.16.0
+        specifier: runtime:^24.17.0
         version: runtime:24.17.0
       prettier:
         specifier: ^3.8.1


### PR DESCRIPTION
This pull request bumps Node.js to version [24.17.0](https://github.com/nodejs/node/releases/tag/v24.17.0).