### PR TITLE
Bump macOS runner in CI to `macos-15`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-14, windows-2022]
+        os: [ubuntu-24.04, macos-15, windows-2022]
     steps:
       - name: Checkout Action
         uses: actions/checkout@v7.0.0
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-14, windows-2022]
+        os: [ubuntu-24.04, macos-15, windows-2022]
     steps:
       - name: Checkout Action
         uses: actions/checkout@v7.0.0
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-14, windows-2022]
+        os: [ubuntu-24.04, macos-15, windows-2022]
     steps:
       - name: Checkout Action
         uses: actions/checkout@v7.0.0


### PR DESCRIPTION
This pull request updates the macOS runner used by the `test` CI workflow from its current version to `macos-15`.
